### PR TITLE
Upgrades to Stack resolver lts-13.4

### DIFF
--- a/snapshot.yaml
+++ b/snapshot.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2018-12-17
+resolver: lts-13.4
 compiler: ghc-8.6.3
 
 name: cardano-snapshot

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,3 +6,6 @@ packages:
 
 nix:
   shell-file: scripts/nix/stack-shell.nix
+
+extra-deps:
+  - pretty-show-1.8.2


### PR DESCRIPTION
This pull request upgrades to the Stack resolver lts-13.4.

The version of `pretty-show` package had to be fixated to <1.9 due to a constraint from the `hedgehog` package.

Closes #24.