### PR TITLE
[#30] Add `assertEitherIsRight` & `assertEitherIsLeft` functions

### DIFF
--- a/test/Test/Cardano/Prelude.hs
+++ b/test/Test/Cardano/Prelude.hs
@@ -6,6 +6,7 @@ where
 import Test.Cardano.Prelude.Base16 as X
 import Test.Cardano.Prelude.Gen as X
 import Test.Cardano.Prelude.Golden as X
+import Test.Cardano.Prelude.Helpers as X
 import Test.Cardano.Prelude.Orphans ()
 import Test.Cardano.Prelude.QuickCheck.Arbitrary as X
 import Test.Cardano.Prelude.QuickCheck.Property as X

--- a/test/Test/Cardano/Prelude/Helpers.hs
+++ b/test/Test/Cardano/Prelude/Helpers.hs
@@ -1,0 +1,24 @@
+module Test.Cardano.Prelude.Helpers
+  ( assertEitherIsLeft
+  , assertEitherIsRight
+  )
+where
+
+import Cardano.Prelude
+
+import Formatting (Buildable, build, sformat)
+
+import Hedgehog (MonadTest, success)
+import Hedgehog.Internal.Property (failWith)
+
+assertEitherIsLeft
+  :: (MonadTest m, Buildable c) => (a -> Either b c) -> a -> m ()
+assertEitherIsLeft func val = case func val of
+  Left  _   -> success
+  Right res -> failWith Nothing (show $ sformat build res)
+
+assertEitherIsRight
+  :: (MonadTest m, Buildable b) => (a -> Either b c) -> a -> m ()
+assertEitherIsRight func val = case func val of
+  Left  err -> failWith Nothing (show $ sformat build err)
+  Right _   -> success

--- a/test/cardano-prelude-test.cabal
+++ b/test/cardano-prelude-test.cabal
@@ -24,6 +24,7 @@ library
                        Test.Cardano.Prelude.Base16
                        Test.Cardano.Prelude.Gen
                        Test.Cardano.Prelude.Golden
+                       Test.Cardano.Prelude.Helpers
                        Test.Cardano.Prelude.Orphans
                        Test.Cardano.Prelude.QuickCheck.Arbitrary
                        Test.Cardano.Prelude.QuickCheck.Property


### PR DESCRIPTION
A couple of helper functions aid testing and nicely render failures of the `Either` datatype.
Closes #30