### PR TITLE
Build internal haddocks in CI

### DIFF
--- a/scripts/buildkite/rebuild.hs
+++ b/scripts/buildkite/rebuild.hs
@@ -41,7 +41,13 @@ buildStep = do
  where
   cfg = ["--dump-logs", "--color", "always"]
   stackBuild args = run "stack" $ cfg ++ ["build", "--fast"] ++ args
-  buildArgs    = ["--bench", "--no-run-benchmarks", "--no-haddock-deps"]
+  buildArgs =
+    [ "--bench"
+    , "--no-run-benchmarks"
+    , "--haddock"
+    , "--haddock-internal"
+    , "--no-haddock-deps"
+    ]
   buildAndTest = stackBuild $ ["--tests"] ++ buildArgs
   build        = stackBuild $ ["--no-run-tests"] ++ buildArgs
   test         = stackBuild ["--test", "--jobs", "1"]


### PR DESCRIPTION
This relates to the two issues in `cardano-chain`:

https://github.com/input-output-hk/cardano-chain/issues/313
https://github.com/input-output-hk/cardano-chain/issues/312

and the [PR in `cardano-chain`](https://github.com/input-output-hk/cardano-chain/pull/357). I thought we could benefit from building haddocks in `cardano-prelude` as well.