### PR TITLE
Add: Fixes for ouroboros-network.

### DIFF
--- a/snapshot.yaml
+++ b/snapshot.yaml
@@ -1,4 +1,4 @@
-resolver: lts-13.15
+resolver: lts-13.16
 compiler: ghc-8.6.4
 
 name: cardano-snapshot
@@ -31,4 +31,9 @@ packages:
   - half-0.2.2.3
   - micro-recursion-schemes-5.0.2.2
   - streaming-binary-0.3.0.1
-  - pretty-show-1.8.2
+  # Work around http://hackage.haskell.org/package/transformers-0.5.5.0/transformers.cabal
+  # This is the version of transformers which ships with GHC-8.6.4
+  - transformers-0.5.6.2
+  # ghc-8.6.4 ships with process-1.6.5.0, not 1.6.3.0 as stackage claims. 1.6.3.0 isn't even compatible with
+  # base 4.12 that ghc ships.
+  - process-1.6.5.0


### PR DESCRIPTION
- We bump the resolver to 13.16
- All stackage GHC resolvers bizarrely pin transformers and process to versions
  which do not actually ship with this GHC. In the case of transformers, this
  pin resolves to a broken version. So we re-pin them to the versions shipped
  with GHC.
- pretty-show is needed at a newer version, and this is now in the snapshot.