### PR TITLE
Add functions and types for building and rendering closure trees

### DIFF
--- a/cardano-prelude.cabal
+++ b/cardano-prelude.cabal
@@ -29,6 +29,7 @@ library
                        Cardano.Prelude.Error
                        Cardano.Prelude.Formatting
                        Cardano.Prelude.GHC.Heap
+                       Cardano.Prelude.GHC.Heap.NormalForm
                        Cardano.Prelude.HeapWords
                        Cardano.Prelude.Json.Canonical
                        Cardano.Prelude.Json.Parse
@@ -75,7 +76,7 @@ test-suite cardano-prelude-test
                        Test.Cardano.Prelude
                        Test.Cardano.Prelude.Base16
                        Test.Cardano.Prelude.Gen
-                       Test.Cardano.Prelude.GHC.Heap
+                       Test.Cardano.Prelude.GHC.Heap.NormalForm
                        Test.Cardano.Prelude.Golden
                        Test.Cardano.Prelude.Helpers
                        Test.Cardano.Prelude.Orphans

--- a/cardano-prelude.cabal
+++ b/cardano-prelude.cabal
@@ -30,6 +30,7 @@ library
                        Cardano.Prelude.Formatting
                        Cardano.Prelude.GHC.Heap
                        Cardano.Prelude.GHC.Heap.NormalForm
+                       Cardano.Prelude.GHC.Heap.Tree
                        Cardano.Prelude.HeapWords
                        Cardano.Prelude.Json.Canonical
                        Cardano.Prelude.Json.Parse
@@ -77,6 +78,7 @@ test-suite cardano-prelude-test
                        Test.Cardano.Prelude.Base16
                        Test.Cardano.Prelude.Gen
                        Test.Cardano.Prelude.GHC.Heap.NormalForm
+                       Test.Cardano.Prelude.GHC.Heap.Tree
                        Test.Cardano.Prelude.Golden
                        Test.Cardano.Prelude.Helpers
                        Test.Cardano.Prelude.Orphans

--- a/src/Cardano/Prelude/GHC/Heap.hs
+++ b/src/Cardano/Prelude/GHC/Heap.hs
@@ -1,96 +1,15 @@
-{-# LANGUAGE DoAndIfThenElse #-}
-
 {-|
 Module      :  Cardano.Prelude.GHC.Heap
-Copyright   :  (c) 2013 Joachim Breitner
-License     :  BSD3
+Copyright   :  (c) 2019 IOHK
+License     :  MIT
 
-This code has been adapted from the module "GHC.AssertNF" of the package
-<http://hackage.haskell.org/package/ghc-heap-view ghc-heap-view>
-(<https://github.com/nomeata/ghc-heap-view GitHub>) authored by
-Joachim Breitner.
-
-To avoid space leaks and unwanted evaluation behaviour, the programmer might want his data to be fully evaluated at certain positions in the code. This can be enforced, for example, by ample use of "Control.DeepSeq", but this comes at a cost.
-
-Experienced users hence use 'Control.DeepSeq.deepseq' only to find out about the existence of space leaks and optimize their code to not create the thunks in the first place, until the code no longer shows better performance with 'deepseq'.
-
-This module provides an alternative approach: An explicit assertion about the evaluation state. If the programmer expect a certain value to be fully evaluated at a specific point of the program (e.g. before a call to 'writeIORef'), he can state that, and as long as assertions are enabled, this statement will be checked. In the production code the assertions can be disabled, to avoid the run-time cost.
-
-Copyright (c) 2012-2013, Joachim Breitner
-
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
-
-    * Neither the name of Joachim Breitner nor the names of other
-      contributors may be used to endorse or promote products derived
-      from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+Functions and data types related to GHC heap internals.
 
 -}
 
 module Cardano.Prelude.GHC.Heap
-  ( isHeadNormalForm
-  , isNormalForm
+  ( module X
   )
 where
 
-import Cardano.Prelude.Base
-
-import GHC.Exts.Heap
-
--- Everything is in normal form, unless it is a
--- thunk explicitly marked as such.
--- Indirection are also considered to be in HNF
-isHeadNormalForm :: Closure -> IO Bool
-isHeadNormalForm c = do
-  case c of
-    ThunkClosure{}    -> return False
-    APClosure{}       -> return False
-    SelectorClosure{} -> return False
-    BCOClosure{}      -> return False
-    _                 -> return True
-
--- | The function 'isNormalForm' checks whether its argument is fully evaluated and
--- deeply evaluated.
-isNormalForm :: a -> IO Bool
-isNormalForm x = isNormalFormBoxed (asBox x)
-
-isNormalFormBoxed :: Box -> IO Bool
-isNormalFormBoxed b = do
-  c  <- getBoxedClosureData b
-  nf <- isHeadNormalForm c
-  if nf
-    then do
-      c' <- getBoxedClosureData b
-      allM isNormalFormBoxed (allClosures c')
-    else do
-      return False
-
--- From Control.Monad.Loops in monad-loops, but I'd like to avoid too many
--- trivial dependencies
-allM :: (Monad m) => (a -> m Bool) -> [a] -> m Bool
-allM _ []       = return True
-allM p (x : xs) = do
-  q <- p x
-  if q then allM p xs else return False
+import Cardano.Prelude.GHC.Heap.NormalForm as X

--- a/src/Cardano/Prelude/GHC/Heap.hs
+++ b/src/Cardano/Prelude/GHC/Heap.hs
@@ -1,7 +1,5 @@
 {-|
 Module      :  Cardano.Prelude.GHC.Heap
-Copyright   :  (c) 2019 IOHK
-License     :  MIT
 
 Functions and data types related to GHC heap internals.
 
@@ -13,3 +11,4 @@ module Cardano.Prelude.GHC.Heap
 where
 
 import Cardano.Prelude.GHC.Heap.NormalForm as X
+import Cardano.Prelude.GHC.Heap.Tree as X

--- a/src/Cardano/Prelude/GHC/Heap/NormalForm.hs
+++ b/src/Cardano/Prelude/GHC/Heap/NormalForm.hs
@@ -1,0 +1,96 @@
+{-# LANGUAGE DoAndIfThenElse #-}
+
+{-|
+Module      :  Cardano.Prelude.GHC.Heap.NormalForm
+Copyright   :  (c) 2013 Joachim Breitner
+License     :  BSD3
+
+This code has been adapted from the module "GHC.AssertNF" of the package
+<http://hackage.haskell.org/package/ghc-heap-view ghc-heap-view>
+(<https://github.com/nomeata/ghc-heap-view GitHub>) authored by
+Joachim Breitner.
+
+To avoid space leaks and unwanted evaluation behaviour, the programmer might want his data to be fully evaluated at certain positions in the code. This can be enforced, for example, by ample use of "Control.DeepSeq", but this comes at a cost.
+
+Experienced users hence use 'Control.DeepSeq.deepseq' only to find out about the existence of space leaks and optimize their code to not create the thunks in the first place, until the code no longer shows better performance with 'deepseq'.
+
+This module provides an alternative approach: An explicit assertion about the evaluation state. If the programmer expect a certain value to be fully evaluated at a specific point of the program (e.g. before a call to 'writeIORef'), he can state that, and as long as assertions are enabled, this statement will be checked. In the production code the assertions can be disabled, to avoid the run-time cost.
+
+Copyright (c) 2012-2013, Joachim Breitner
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Joachim Breitner nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+-}
+
+module Cardano.Prelude.GHC.Heap.NormalForm
+  ( isHeadNormalForm
+  , isNormalForm
+  )
+where
+
+import Cardano.Prelude.Base
+
+import GHC.Exts.Heap
+
+-- Everything is in normal form, unless it is a
+-- thunk explicitly marked as such.
+-- Indirection are also considered to be in HNF
+isHeadNormalForm :: Closure -> IO Bool
+isHeadNormalForm c = do
+  case c of
+    ThunkClosure{}    -> return False
+    APClosure{}       -> return False
+    SelectorClosure{} -> return False
+    BCOClosure{}      -> return False
+    _                 -> return True
+
+-- | The function 'isNormalForm' checks whether its argument is fully evaluated and
+-- deeply evaluated.
+isNormalForm :: a -> IO Bool
+isNormalForm x = isNormalFormBoxed (asBox x)
+
+isNormalFormBoxed :: Box -> IO Bool
+isNormalFormBoxed b = do
+  c  <- getBoxedClosureData b
+  nf <- isHeadNormalForm c
+  if nf
+    then do
+      c' <- getBoxedClosureData b
+      allM isNormalFormBoxed (allClosures c')
+    else do
+      return False
+
+-- From Control.Monad.Loops in monad-loops, but I'd like to avoid too many
+-- trivial dependencies
+allM :: (Monad m) => (a -> m Bool) -> [a] -> m Bool
+allM _ []       = return True
+allM p (x : xs) = do
+  q <- p x
+  if q then allM p xs else return False

--- a/src/Cardano/Prelude/GHC/Heap/Tree.hs
+++ b/src/Cardano/Prelude/GHC/Heap/Tree.hs
@@ -1,0 +1,111 @@
+{-# LANGUAGE BangPatterns      #-}
+{-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+{-|
+Module      :  Cardano.Prelude.GHC.Heap.Tree
+
+This module exports functions and data types for building and printing GHC
+heap object trees. Very useful for debugging issues involving the heap
+representation of Haskell expressions.
+
+-}
+
+module Cardano.Prelude.GHC.Heap.Tree
+  ( ClosureTreeOptions(..)
+  , TraverseCyclicClosures(..)
+  , TreeDepth(..)
+  , buildClosureTree
+  , buildAndRenderClosureTree
+  , depth
+  , isZeroOrNegativeTreeDepth
+  , renderClosure
+  , renderTree
+  )
+where
+
+import Cardano.Prelude.Base
+
+import Data.Text (pack, unpack)
+import Data.Tree (Tree(..), drawTree, levels)
+import GHC.Exts.Heap
+  (Box(..), Closure, allClosures, areBoxesEqual, asBox, getClosureData)
+import System.Mem (performGC)
+
+-- | The depth of a 'Tree'.
+data TreeDepth
+  = TreeDepth {-# UNPACK #-} !Int
+  -- ^ A specific tree depth bound.
+  | AnyDepth
+  -- ^ No tree depth bound.
+  deriving (Show)
+
+-- | Whether to traverse cyclic closures in a 'Closure' 'Tree'.
+data TraverseCyclicClosures
+  = TraverseCyclicClosures
+  -- ^ Traverse cyclic closures.
+  | NoTraverseCyclicClosures
+  -- ^ Do not traverse cyclic closures.
+  deriving (Show)
+
+-- | Options which detail how a 'Closure' 'Tree' should be constructed.
+data ClosureTreeOptions = ClosureTreeOptions
+  { ctoMaxDepth       :: !TreeDepth
+  -- ^ Construct a closure tree given a maximum depth.
+  , ctoCyclicClosures :: !TraverseCyclicClosures
+  -- ^ Whether to traverse cyclic closures while constructing a closure tree.
+  } deriving (Show)
+
+depth :: Tree a -> Int
+depth = length . levels
+
+isZeroOrNegativeTreeDepth :: TreeDepth -> Bool
+isZeroOrNegativeTreeDepth AnyDepth = False
+isZeroOrNegativeTreeDepth (TreeDepth d)
+  | d <= 0    = True
+  | otherwise = False
+
+renderClosure :: Closure -> Text
+renderClosure = show
+
+renderTree :: Tree a -> (a -> Text) -> Text
+renderTree tree renderA = pack $ drawTree (fmap (unpack . renderA) tree)
+
+-- | Given a Haskell expression, build a 'Tree' which reflects its heap object
+-- representation.
+buildClosureTree :: ClosureTreeOptions -> a -> IO (Maybe (Tree Closure))
+buildClosureTree opts x = do
+  performGC
+  go opts [] $ asBox x
+ where
+  go :: ClosureTreeOptions -> [Box] -> Box -> IO (Maybe (Tree Closure))
+  go (ClosureTreeOptions { ctoMaxDepth, ctoCyclicClosures }) !vs b@(Box y)
+    | isZeroOrNegativeTreeDepth ctoMaxDepth = pure Nothing
+    | otherwise = do
+      let
+        nextMaxDepth = case ctoMaxDepth of
+          AnyDepth    -> AnyDepth
+          TreeDepth d -> TreeDepth (d - 1)
+        nextOpts = ClosureTreeOptions nextMaxDepth ctoCyclicClosures
+      case ctoCyclicClosures of
+        NoTraverseCyclicClosures -> do
+          isElem <- liftM or $ mapM (areBoxesEqual b) vs
+          if isElem
+            then pure Nothing
+            else do
+              closure  <- getClosureData y
+              subtrees <- mapM (go nextOpts (b : vs)) (allClosures closure)
+              pure (Just (Node closure (catMaybes subtrees)))
+        TraverseCyclicClosures -> do
+          closure  <- getClosureData y
+          subtrees <- mapM (go nextOpts (b : vs)) (allClosures closure)
+          pure (Just (Node closure (catMaybes subtrees)))
+
+-- | Given a Haskell expression, build a 'Tree' which reflects its heap object
+-- representation and render it as 'Text'.
+buildAndRenderClosureTree :: ClosureTreeOptions -> a -> IO Text
+buildAndRenderClosureTree opts x = do
+  mbTr <- buildClosureTree opts x
+  case mbTr of
+    Nothing -> pure mempty
+    Just tr -> pure (renderTree tr renderClosure)

--- a/test/Test/Cardano/Prelude/GHC/Heap/NormalForm.hs
+++ b/test/Test/Cardano/Prelude/GHC/Heap/NormalForm.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 
-module Test.Cardano.Prelude.GHC.Heap
+module Test.Cardano.Prelude.GHC.Heap.NormalForm
   ( tests
   )
 where

--- a/test/Test/Cardano/Prelude/GHC/Heap/Tree.hs
+++ b/test/Test/Cardano/Prelude/GHC/Heap/Tree.hs
@@ -1,0 +1,83 @@
+{-# LANGUAGE DeriveAnyClass    #-}
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE TemplateHaskell   #-}
+
+module Test.Cardano.Prelude.GHC.Heap.Tree
+  ( tests
+  )
+where
+
+import Cardano.Prelude
+
+import Control.Applicative ((<$>))
+import Data.Text (unpack)
+import Hedgehog
+  ( Gen
+  , Property
+  , checkParallel
+  , discover
+  , failure
+  , forAll
+  , property
+  , withTests
+  , annotate
+  , (===)
+  )
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+-- | Property: The depth of a `[Word8]`'s closure tree is its length + 1.
+-- n.b. The (+ 1) is for the `[]` constructor at the end.
+prop_Word8ListClosureTreeDepth :: Property
+prop_Word8ListClosureTreeDepth =
+  withTests 500
+    $ property
+    $ do
+        let
+          genElem :: Gen Word8
+          genElem = Gen.word8 Range.constantBounded
+        listLen <- forAll $ Gen.int (Range.constant 0 500)
+        xs      <- forAll $ Gen.list (Range.singleton listLen) genElem
+        let
+          maxTreeDepth = AnyDepth -- This should be okay since, in this property,
+                                  -- the maximum depth of a generated tree can
+                                  -- only be `listLen + 1`.
+          travCycClos  = NoTraverseCyclicClosures
+          opts         = ClosureTreeOptions maxTreeDepth travCycClos
+        mbClosureTree <- liftIO $ buildClosureTree opts $!! xs
+        case mbClosureTree of
+          Nothing -> do
+            annotate "prop_Word8ListClosureTreeDepth: Impossible"
+            failure
+          Just ct -> do
+            annotate $ unpack (renderTree ct renderClosure)
+            depth ct === (length xs) + 1
+
+-- | Property: Specifying a 'TreeDepth' other than 'AnyDepth' should
+-- appropriately limit the maximum depth of the 'Closure' 'Tree' generated.
+-- i.e. If we specify a maximum depth of @TreeDepth maxDepth@, we would expect
+-- that the depth of the 'Closure' 'Tree', @closureTree@, would either be
+-- @maxDepth@ or, @if depth closureTree < maxDepth@, @depth closureTree@.
+prop_ClosureTreeHasSpecifiedDepth :: Property
+prop_ClosureTreeHasSpecifiedDepth = withTests 500 $ property $ do
+  let
+    genElem :: Gen Word8
+    genElem = Gen.word8 Range.constantBounded
+  listLen  <- forAll $ Gen.int (Range.constant 0 500)
+  xs       <- forAll $ Gen.list (Range.singleton listLen) genElem
+  maxDepth <- forAll $ Gen.int (Range.constant 0 1000)
+  let
+    travCycClos  = NoTraverseCyclicClosures
+    maxTreeDepth = TreeDepth maxDepth
+    opts         = ClosureTreeOptions maxTreeDepth travCycClos
+  mbClosureTree <- liftIO $ buildClosureTree opts $!! xs
+  case mbClosureTree of
+    Nothing -> maxDepth === 0
+    Just ct -> do
+      annotate $ unpack (renderTree ct renderClosure)
+      if depth ct < maxDepth
+        then depth ct === (length xs) + 1
+        else depth ct === maxDepth
+
+tests :: IO Bool
+tests = and <$> sequence [checkParallel $$(discover)]

--- a/test/test.hs
+++ b/test/test.hs
@@ -6,7 +6,7 @@ where
 import Cardano.Prelude
 import Test.Cardano.Prelude
 
-import qualified Test.Cardano.Prelude.GHC.Heap
+import qualified Test.Cardano.Prelude.GHC.Heap.NormalForm
 
 main :: IO ()
-main = runTests [Test.Cardano.Prelude.GHC.Heap.tests]
+main = runTests [Test.Cardano.Prelude.GHC.Heap.NormalForm.tests]

--- a/test/test.hs
+++ b/test/test.hs
@@ -7,6 +7,10 @@ import Cardano.Prelude
 import Test.Cardano.Prelude
 
 import qualified Test.Cardano.Prelude.GHC.Heap.NormalForm
+import qualified Test.Cardano.Prelude.GHC.Heap.Tree
 
 main :: IO ()
-main = runTests [Test.Cardano.Prelude.GHC.Heap.NormalForm.tests]
+main = runTests
+  [ Test.Cardano.Prelude.GHC.Heap.NormalForm.tests
+  , Test.Cardano.Prelude.GHC.Heap.Tree.tests
+  ]


### PR DESCRIPTION
These functions and data types have been very useful when needing to visualize and debug the GHC heap object representation of Haskell expressions. For e.g., it's been useful for finding thunks in instances of `cardano-ledger` data types which we keep in-memory such as `ChainValidationState`.