### PR TITLE
Downgrade `pretty-show` to resolve dependency issues downstream

### DIFF
--- a/snapshot.yaml
+++ b/snapshot.yaml
@@ -32,3 +32,5 @@ packages:
   # ghc-8.6.4 ships with process-1.6.5.0, not 1.6.3.0 as stackage claims. 1.6.3.0 isn't even compatible with
   # base 4.12 that ghc ships.
   - process-1.6.5.0
+  # Resolve dependency issues in cardano-shell
+  - pretty-show-1.8.2


### PR DESCRIPTION
`cardano-shell` depends on `hedgehog` and `cardano-prelude` which both depend on different versions of `pretty-show`. Rather than have two versions of `pretty-show` in `cardano-shell` we opted to downgrade `pretty-show` here.