### PR TITLE
Expose canonical pretty encoding/decoding functions

### DIFF
--- a/cardano-prelude.cabal
+++ b/cardano-prelude.cabal
@@ -73,6 +73,9 @@ test-suite cardano-prelude-test
   main-is:             test.hs
   type:                exitcode-stdio-1.0
 
+  exposed-modules:
+                       Test.Cardano.Prelude
+
   other-modules:
                        Test.Cardano.Prelude
                        Test.Cardano.Prelude.Base16


### PR DESCRIPTION
`cardano-node` uses these functions.