### PR TITLE
Update gitignore; cabal.project; aeson-pretty version bounds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 */dist
 dist-newstyle/
 cabal.project.local
+.ghc.environment.*
 
 # Editors
 TAGS

--- a/cabal.project
+++ b/cabal.project
@@ -1,2 +1,3 @@
 packages:
   ./
+  ./test

--- a/cardano-prelude.cabal
+++ b/cardano-prelude.cabal
@@ -91,7 +91,7 @@ test-suite cardano-prelude-test
 
   build-depends:       base
                      , aeson
-                     , aeson-pretty
+                     , aeson-pretty >= 0.8.5
                      , attoparsec
                      , base16-bytestring
                      , bytestring

--- a/test/cardano-prelude-test.cabal
+++ b/test/cardano-prelude-test.cabal
@@ -32,7 +32,7 @@ library
 
   build-depends:       base
                      , aeson
-                     , aeson-pretty
+                     , aeson-pretty >= 0.8.5
                      , attoparsec
                      , base16-bytestring
                      , bytestring


### PR DESCRIPTION
`aeson-pretty`'s Config datatype was updated in 0.8.5 to have a 4th
field. This wasn't captured in the cabal file and I ran into a build
error in a downstream package when an older version of `aeson-pretty`
was built which lacked the 4th field.

I also add /test to the `cabal.project` and gitignore the GHC env file.