### PR TITLE
Add protolude upper bound

### DIFF
--- a/cardano-prelude.cabal
+++ b/cardano-prelude.cabal
@@ -53,7 +53,7 @@ library
                      , integer-gmp
                      , mtl
                      , nonempty-containers
-                     , protolude
+                     , protolude                  < 0.2.4
                      , tagged
                      , text
                      , time

--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -5,7 +5,6 @@
         "base58-bytestring" = (((hackage.base58-bytestring)."0.1.0").revisions).default;
         "hedgehog" = (((hackage.hedgehog)."1.0").revisions).default;
         "micro-recursion-schemes" = (((hackage.micro-recursion-schemes)."5.0.2.2").revisions).default;
-        "protolude" = (((hackage.protolude)."0.2.4").revisions).default;
         "streaming-binary" = (((hackage.streaming-binary)."0.3.0.1").revisions).default;
         "cborg" = (((hackage.cborg)."0.2.2.0").revisions).default;
         "canonical-json" = (((hackage.canonical-json)."0.6.0.0").revisions).default;

--- a/snapshot.yaml
+++ b/snapshot.yaml
@@ -11,7 +11,6 @@ packages:
   # Waiting on Stackage release
   - hedgehog-1.0
   - micro-recursion-schemes-5.0.2.2
-  - protolude-0.2.4
   - streaming-binary-0.3.0.1
   - cborg-0.2.2.0
   - canonical-json-0.6.0.0

--- a/test/Test/Cardano/Prelude/Tripping.hs
+++ b/test/Test/Cardano/Prelude/Tripping.hs
@@ -21,7 +21,7 @@ module Test.Cardano.Prelude.Tripping
   )
 where
 
-import Cardano.Prelude hiding (unlines)
+import Cardano.Prelude
 
 import Data.Aeson (FromJSON, ToJSON, decode, encode)
 import Data.String (String, unlines)


### PR DESCRIPTION
Protolude 0.2.4 exposes 'Text.words', 'Text.unlines' and others
which cause compile failures later in the dependency chain.