### PR TITLE
Define `gshowsPrecWithoutRecordSyntax`

### DIFF
--- a/cardano-prelude.cabal
+++ b/cardano-prelude.cabal
@@ -40,6 +40,7 @@ library
                        Cardano.Prelude.Json.Canonical
                        Cardano.Prelude.Json.Parse
                        Cardano.Prelude.Orphans
+                       Cardano.Prelude.Show
                        Cardano.Prelude.Strict
 
   build-depends:       base
@@ -52,6 +53,7 @@ library
                      , containers
                      , fingertree
                      , formatting
+                     , generic-deriving
                      , ghc-heap
                      , ghc-prim
                      , hashable
@@ -102,6 +104,7 @@ test-suite cardano-prelude-test
                        Test.Cardano.Prelude.Orphans
                        Test.Cardano.Prelude.QuickCheck.Arbitrary
                        Test.Cardano.Prelude.QuickCheck.Property
+                       Test.Cardano.Prelude.Show
                        Test.Cardano.Prelude.Tripping
 
   build-depends:       base

--- a/nix/.stack.nix/cardano-prelude.nix
+++ b/nix/.stack.nix/cardano-prelude.nix
@@ -67,6 +67,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           (hsPkgs."containers" or (buildDepError "containers"))
           (hsPkgs."fingertree" or (buildDepError "fingertree"))
           (hsPkgs."formatting" or (buildDepError "formatting"))
+          (hsPkgs."generic-deriving" or (buildDepError "generic-deriving"))
           (hsPkgs."ghc-heap" or (buildDepError "ghc-heap"))
           (hsPkgs."ghc-prim" or (buildDepError "ghc-prim"))
           (hsPkgs."hashable" or (buildDepError "hashable"))

--- a/src/Cardano/Prelude.hs
+++ b/src/Cardano/Prelude.hs
@@ -12,4 +12,5 @@ import Cardano.Prelude.HeapWords as X
 import Cardano.Prelude.Json.Canonical as X
 import Cardano.Prelude.Json.Parse as X
 import Cardano.Prelude.Orphans ()
+import Cardano.Prelude.Show as X
 import Cardano.Prelude.Strict as X

--- a/src/Cardano/Prelude/Show.hs
+++ b/src/Cardano/Prelude/Show.hs
@@ -1,0 +1,114 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}   -- for Rep WRAP
+
+-- | This module uses "GHC.Generics" to define 'gshowsPrecWithoutRecordSyntax',
+-- which can often make the result of 'show' more legible, especially for
+-- @newtype@s for example.
+--
+module Cardano.Prelude.Show (
+    gshowsPrecWithoutRecordSyntax,
+    GShowK1 (..),
+    WithoutRecordSyntax,
+  ) where
+
+import           Prelude
+
+import           Data.Coerce
+import           Data.Kind (Type)
+import           GHC.Generics
+
+import qualified Generics.Deriving.Show as GD
+
+-- | Implements 'showsPrec' as if the constructors' record fields were instead
+-- plain arguments
+--
+gshowsPrecWithoutRecordSyntax ::
+  forall a.
+     ( Generic a
+     , Coercible (Rep a) (WithoutRecordSyntax (Rep a))
+     , GD.GShow' (WithoutRecordSyntax (Rep a))
+     )
+  => Int -> a -> ShowS
+gshowsPrecWithoutRecordSyntax p =
+    GD.gshowsPrecdefault p . WRAP
+
+{-------------------------------------------------------------------------------
+  Forgetting fields
+-------------------------------------------------------------------------------}
+
+-- not exported
+newtype WRAP a = WRAP a
+
+-- Without this definition, GHC cannot make the same inference at the usage
+-- sites within this module, probably because f and g involve type families
+--
+coerce1 :: Coercible f g => f a -> g a
+coerce1 x = coerce x
+
+instance
+  ( Generic a
+  , Coercible (Rep a) (WithoutRecordSyntax (Rep a))
+  ) => Generic (WRAP a)
+  where
+    type Rep (WRAP a) = WithoutRecordSyntax (Rep a)
+
+    to = WRAP . to . coerce1
+    from (WRAP a) = (coerce1 . from) a
+
+-- | An implementation detail of 'gshowsPrecWithoutRecordSyntax'
+--
+-- This removes the metadata in a "GHC.Generics" 'Rep' instance incurred by the
+-- use of record syntax in the data type declaration. It also replaces 'K1'
+-- with 'GShowK1'.
+--
+-- The result is as if the constructors' record fields were instead plain
+-- arguments, modulo the 'K1' and 'GShowK1' swap.
+--
+type family WithoutRecordSyntax (rep :: Type -> Type) :: Type -> Type where
+    -- the interesting case
+    WithoutRecordSyntax (M1 i c f) = M1 i (WithoutRecordSyntaxMeta c) (WithoutRecordSyntax f)
+
+    -- the tedious case
+    --
+    -- GShow' (K1 i c) requires GShow c, whereas we want it to use Show c
+    -- instead
+    WithoutRecordSyntax (K1 i c) = GShowK1 i c
+
+    -- the mundane recursive cases
+    WithoutRecordSyntax (a :+: b)  = WithoutRecordSyntax a :+: WithoutRecordSyntax b
+    WithoutRecordSyntax (a :*: b)  = WithoutRecordSyntax a :*: WithoutRecordSyntax b
+    WithoutRecordSyntax (a :.: b)  = WithoutRecordSyntax a :.: WithoutRecordSyntax b
+
+    -- the mundane base cases
+    WithoutRecordSyntax V1           = V1
+    WithoutRecordSyntax U1           = U1
+    WithoutRecordSyntax UChar        = UChar
+    WithoutRecordSyntax UDouble      = UDouble
+    WithoutRecordSyntax UFloat       = UFloat
+    WithoutRecordSyntax UInt         = UInt
+    WithoutRecordSyntax UWord        = UWord
+
+-- | Remove data about field selectors
+--
+type family WithoutRecordSyntaxMeta (rep :: Meta) :: Meta where
+    WithoutRecordSyntaxMeta ('MetaSel 'Nothing  su ss ds) = 'MetaSel 'Nothing su ss ds
+    WithoutRecordSyntaxMeta ('MetaSel ('Just _) su ss ds) = 'MetaSel 'Nothing su ss ds
+    WithoutRecordSyntaxMeta ('MetaCons n f _s)            = 'MetaCons n f 'False
+    WithoutRecordSyntaxMeta ('MetaData n m p nt)          = 'MetaData n m p nt
+
+-- | Merely an implementation detail
+--
+-- This constructor must be in scope at usage sites of 'gshowsPrecWithoutRecordSyntax'
+-- for its 'Coercible' constraint to be satisfiable.
+--
+newtype GShowK1 i c p = GShowK1 (K1 i c p)
+
+instance Show c => GD.GShow' (GShowK1 i c) where
+    gshowsPrec' _ p (GShowK1 (K1 c)) = showsPrec p c
+
+    -- copied from @GShow' (K1 i c)@ instance in @generic-deriving@
+    isNullary _ = False

--- a/test/Test/Cardano/Prelude/Show.hs
+++ b/test/Test/Cardano/Prelude/Show.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE DeriveGeneric   #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Test.Cardano.Prelude.Show (
+  tests,
+  ) where
+
+import qualified Prelude
+
+import           GHC.Generics (Generic)
+
+import Hedgehog
+  ( Property
+  , (===)
+  , checkParallel
+  , discover
+  , property
+  , withTests
+  )
+
+import           Cardano.Prelude
+
+-----
+
+prop_T1 :: Property
+prop_T1 = withTests 1 $ property $
+  Prelude.show (T1 7) === "T1 7"
+
+newtype T1 = T1 {t1Int :: Int}
+  deriving (Generic)
+
+instance Prelude.Show T1 where
+  showsPrec = gshowsPrecWithoutRecordSyntax
+
+-----
+
+prop_T2 :: Property
+prop_T2 = withTests 1 $ property $
+  Prelude.show (T2 1 'a') === "T2 1 'a'"
+
+data T2 = T2 {t2Int :: Int, t2Char :: Char}
+  deriving (Generic)
+
+instance Prelude.Show T2 where
+  showsPrec = gshowsPrecWithoutRecordSyntax
+
+-----
+
+prop_T3A :: Property
+prop_T3A = withTests 1 $ property $
+  Prelude.show (T3A 1 'b') === "T3A 1 'b'"
+
+prop_T3B :: Property
+prop_T3B = withTests 1 $ property $
+  Prelude.show (T3B 'x' 3) === "T3B 'x' 3"
+
+data T3
+  = T3A {t3Int :: Int, t3Char :: Char}
+  | T3B {t3Char :: Char, t3Int :: Int}
+  deriving (Generic)
+
+instance Prelude.Show T3 where
+  showsPrec = gshowsPrecWithoutRecordSyntax
+
+----- last, so TemplateHaskell sees all prop_*
+
+tests :: IO Bool
+tests = and <$> sequence [checkParallel $$(discover)]

--- a/test/test.hs
+++ b/test/test.hs
@@ -10,6 +10,7 @@ import qualified Test.Cardano.Prelude.GHC.Heap.NormalForm
 import qualified Test.Cardano.Prelude.GHC.Heap.NormalForm.Classy
 import qualified Test.Cardano.Prelude.GHC.Heap.Size
 import qualified Test.Cardano.Prelude.GHC.Heap.Tree
+import qualified Test.Cardano.Prelude.Show
 
 main :: IO ()
 main = runTests
@@ -17,4 +18,5 @@ main = runTests
   , Test.Cardano.Prelude.GHC.Heap.NormalForm.Classy.tests
   , Test.Cardano.Prelude.GHC.Heap.Size.tests
   , Test.Cardano.Prelude.GHC.Heap.Tree.tests
+  , Test.Cardano.Prelude.Show.tests
   ]


### PR DESCRIPTION
Commenters on input-output-hk/ouroboros-network#1019 suggested I define the generic function in this repo.

With this new `gshowsPrecForgetFields` function, you can derive `Show X` as follows. The instance will behave as if `X`'s constructors' definitions have no record selectors, even if they do.

```
data X = ...
  deriving (Generic {- ... and whatever else except Show -})

instance Show X where
  showsPrec = gshowsPrecForgetFields
```

Remarks:
  * The result of `show` is still "copy-pasteable" as code.
  * This makes some types' `show` output much more legible, especially `newtype`s.

This PR doesn't add uses of `gshowsPrecForgetFields`; that'll be done in follow-up PRs. I personally plan to use it for some types in the `ouroboros-network` repo, for example.