### PR TITLE
Remove cardano-crypto package from snapshot.yaml

### DIFF
--- a/snapshot.yaml
+++ b/snapshot.yaml
@@ -4,9 +4,6 @@ compiler: ghc-8.6.5
 name: cardano-snapshot
 
 packages:
-  - git: https://github.com/input-output-hk/cardano-crypto
-    commit: 3c707936ba0a665375acf5bd240dc4b6eaa6c0bc
-
     # Contains fix for cbor pretty printing
   - git: https://github.com/well-typed/cborg
     commit: 42a83192749774268337258f4f94c97584b80ca6


### PR DESCRIPTION
`cardano-crypto` is not used in this project.

Downstream packages using this `snapshot.yaml` as their resolver automatically get this `cardano-crypto` version pin, *but only for Stack*. The `cabal.project` of these repositories must then contain a version pin for `cardano-crypto`. This means that the hashes of these two are likely to get out of sync (one is defined in cardano-prelude and the other in the repository in question, e.g., ouroboros-network). Moreover, it's inconsistent for repositories to have a version pin in `cabal.project` but not in `stack.yaml`.

A breaking, but intentional consequence of this change is that downstream repositories will need to add a version pin on cardano-crypto to their `stack.yaml`.