### PR TITLE
Add GWhnfNoUnexpectedThunks V1 instance

### DIFF
--- a/src/Cardano/Prelude/GHC/Heap/NormalForm/Classy.hs
+++ b/src/Cardano/Prelude/GHC/Heap/NormalForm/Classy.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE KindSignatures        #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE PolyKinds             #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE StandaloneDeriving    #-}
@@ -445,6 +446,12 @@ instance NoUnexpectedThunks c => GWhnfNoUnexpectedThunks a (K1 i c) where
 
 instance GWhnfNoUnexpectedThunks a U1 where
   gWhnfNoUnexpectedThunks _a _ctxt U1 = return NoUnexpectedThunks
+
+instance GWhnfNoUnexpectedThunks a V1 where
+  -- By assumption, the argument is already in WHNF. Since every inhabitant of
+  -- this type is bottom, this code is therefore unreachable.
+  gWhnfNoUnexpectedThunks _a _ctxt _ =
+      panic "unreachable gWhnfNoUnexpectedThunks @V1"
 
 {-------------------------------------------------------------------------------
   Internal: generic function to get name of a type


### PR DESCRIPTION
I haven't immersed myself in this code as deeply as I would like to. But this seems like the right change.

What do you think, @mrBliss, is my logic (see comment) sound here? I noticed this instance is missing when I opened input-output-hk/cardano-ledger-specs#1306 and input-output-hk/cardano-ledger-specs#1307 earlier today.