### PR TITLE
Improve debugability of roundTripsAesonShow

### DIFF
--- a/test/Test/Cardano/Prelude/Tripping.hs
+++ b/test/Test/Cardano/Prelude/Tripping.hs
@@ -21,7 +21,7 @@ where
 
 import Cardano.Prelude
 
-import Data.Aeson (FromJSON, ToJSON, decode, encode)
+import Data.Aeson (FromJSON, ToJSON, decode, fromJSON, encode, toJSON)
 import Data.String (String, unlines)
 import Data.Functor.Identity (Identity(..))
 import qualified Data.Map as Map
@@ -98,7 +98,7 @@ discoverPrefixThreadArg prefix = do
 
 roundTripsAesonShow
   :: (Eq a, MonadTest m, ToJSON a, FromJSON a, Show a) => a -> m ()
-roundTripsAesonShow a = tripping a encode decode
+roundTripsAesonShow a = tripping a toJSON fromJSON
 
 -- | Round trip any `a` with both `ToJSON` and `FromJSON` instances.
 roundTripsAesonBuildable


### PR DESCRIPTION
When using the 'Data.Aeson.decode' function, decode failures do not
result in any useful debug message other than the generated value.
Switching to 'Data.Aeson.fromJSON' fixes this. It means the value is
only encoded to an 'Data.Aeson.Value' type but that should be sufficient.