### PR TITLE
Base16: Use explicit function instead of typeclass foo

### DIFF
--- a/src/Cardano/Prelude/Base16.hs
+++ b/src/Cardano/Prelude/Base16.hs
@@ -12,6 +12,7 @@ import Cardano.Prelude.Base
 
 import qualified Data.ByteString.Base16 as B16
 import qualified Data.ByteString.Char8 as BS
+import qualified Data.Text.Encoding as Text
 import Formatting (bprint, shown)
 import Formatting.Buildable (Buildable(build))
 
@@ -26,6 +27,6 @@ instance Buildable Base16ParseError where
 
 parseBase16 :: Text -> Either Base16ParseError ByteString
 parseBase16 s = do
-  let (bs, suffix) = B16.decode $ toS s
+  let (bs, suffix) = B16.decode $ Text.encodeUtf8 s
   unless (BS.null suffix) . Left $ Base16IncorrectSuffix suffix
   pure bs


### PR DESCRIPTION
Was getting a build failure further up the stack complaining of
a missing 'ConvertText Text ByteString' instance. This must have
changed in an upstream library. Use an explicit conversion instead.

Closes: https://github.com/input-output-hk/cardano-prelude/issues/110