### PR TITLE
Remove unused imports

### DIFF
--- a/cardano-prelude.cabal
+++ b/cardano-prelude.cabal
@@ -76,6 +76,12 @@ library
                        -fno-warn-missing-import-lists
                        -fno-warn-unsafe
                        -fno-warn-safe
+  if impl(ghc >=8.8)
+    ghc-options:       -Wno-missing-deriving-strategies
+  if impl(ghc >=8.10)
+    ghc-options:       -Wno-prepositive-qualified-module
+                       -Wno-missing-safe-haskell-mode
+
   cc-options:          -Wall
 
   if (!flag(development))

--- a/src/Cardano/Prelude/Base.hs
+++ b/src/Cardano/Prelude/Base.hs
@@ -21,7 +21,6 @@ import Protolude as X
   )
 import qualified Protolude as Y
 
-import Data.Foldable (Foldable)
 import Data.Map.Strict as X (Map)
 import qualified Data.Text as T
 

--- a/src/Cardano/Prelude/Formatting.hs
+++ b/src/Cardano/Prelude/Formatting.hs
@@ -36,7 +36,6 @@ where
 
 import Cardano.Prelude.Base
 
-import Data.ByteString (ByteString)
 import qualified Data.ByteString.Base16 as B16
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.Text.Lazy as LT

--- a/src/Cardano/Prelude/GHC/Heap/NormalForm/Classy.hs
+++ b/src/Cardano/Prelude/GHC/Heap/NormalForm/Classy.hs
@@ -41,9 +41,6 @@ module Cardano.Prelude.GHC.Heap.NormalForm.Classy (
 
 import Cardano.Prelude.Base
 
-import Data.Foldable (toList)
-import Data.Sequence (Seq)
-import Data.List.NonEmpty (NonEmpty)
 import Data.Time
 import GHC.Exts.Heap (asBox, getBoxedClosureData)
 import GHC.TypeLits (CmpSymbol)

--- a/src/Cardano/Prelude/HeapWords.hs
+++ b/src/Cardano/Prelude/HeapWords.hs
@@ -31,13 +31,10 @@ import qualified Data.Array.Unboxed as A
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.ByteString.Short as BSS
-import Data.IntMap (IntMap)
 import qualified Data.IntMap.Strict as IntMap
-import Data.IntSet (IntSet)
 import qualified Data.IntSet as IntSet
 import Data.Ix
 import qualified Data.Map.Strict as Map
-import Data.Sequence (Seq)
 import qualified Data.Set as Set
 import Data.Time (Day, UTCTime)
 import qualified Data.Vector as V

--- a/src/Cardano/Prelude/Json/Canonical.hs
+++ b/src/Cardano/Prelude/Json/Canonical.hs
@@ -21,7 +21,6 @@ where
 
 import Cardano.Prelude.Base
 
-import Control.Monad.Except (MonadError(throwError))
 import qualified Data.ByteString.Lazy as LB
 import Data.Fixed (E12, resolution)
 import qualified Data.Text.Lazy.Builder as Builder (fromText)

--- a/src/Cardano/Prelude/Json/Parse.hs
+++ b/src/Cardano/Prelude/Json/Parse.hs
@@ -13,7 +13,6 @@ where
 import Cardano.Prelude.Base
 
 import Data.String (String)
-import Data.Typeable (typeRep)
 import Formatting (Format, build, formatToString, string)
 import Formatting.Buildable (Buildable)
 import Text.JSON.Canonical

--- a/src/Cardano/Prelude/Orphans.hs
+++ b/src/Cardano/Prelude/Orphans.hs
@@ -16,7 +16,6 @@ import Data.Aeson (FromJSON(..), ToJSON(..))
 import Data.Set.NonEmpty (NESet)
 import qualified Data.Set.NonEmpty as NES
 import Data.Tagged (Tagged(Tagged))
-import Data.Typeable (typeRep)
 import qualified Formatting as F
 import Formatting.Buildable (Buildable(..))
 

--- a/src/Data/FingerTree/Strict.hs
+++ b/src/Data/FingerTree/Strict.hs
@@ -53,8 +53,6 @@ import           Prelude hiding (null, reverse)
 import           Data.FingerTree (Measured (..), ViewL (..), ViewR (..))
 import qualified Data.FingerTree as FT
 import           Data.Foldable (foldl', toList)
-import           Data.Monoid (Monoid (..))
-import           Data.Semigroup (Semigroup (..))
 import           GHC.Generics (Generic)
 
 import           Cardano.Prelude (NoUnexpectedThunks (..),


### PR DESCRIPTION
cardano-prelude compiles with GHC-8.8 and GHC-8.10 just fine atm.

- We need to remove some new warnings from -Weverything
- Unused/redundant imports warning is stricter,
  and spotted some redundant imports