### PR TITLE
CircleCI configuration, that compiles for multiple GHC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,65 @@
+version: 2.1
+
+orbs:
+  haskell: haskell-works/haskell-build@4.1.7
+  github: haskell-works/github-release@1.3.3
+  hackage: haskell-works/hackage@1.4.2
+  merge-point: haskell-works/merge-point@1.0.0
+
+workflows:
+  multiple-ghc-build:
+    jobs:
+      - haskell/build-with-binary-cache:
+          name: GHC 8.6.5
+          executor: haskell/ghc-8_6_5
+          context: haskell-ci
+          fail-incoherent-builds: false
+          run-check: false
+          binary-cache-uri: ${BINARY_CACHE_URI-"http://hw-binary-cache-us-west-2-a.s3-website-us-west-2.amazonaws.com/archive"}
+          cabal-build-extra: --write-ghc-environment-files=ghc8.4.4+
+          cabal-test-extra: --test-show-details=direct --test-options='+RTS -g1'
+
+      - haskell/build-with-binary-cache:
+          name: GHC 8.8.3
+          executor: haskell/ghc-8_8_3
+          context: haskell-ci
+          fail-incoherent-builds: false
+          run-check: false
+          binary-cache-uri: ${BINARY_CACHE_URI-"http://hw-binary-cache-us-west-2-a.s3-website-us-west-2.amazonaws.com/archive"}
+          cabal-build-extra: --write-ghc-environment-files=ghc8.4.4+
+          cabal-test-extra: --test-show-details=direct --test-options='+RTS -g1'
+
+      - haskell/build-with-binary-cache:
+          name: GHC 8.10.1
+          executor: haskell/ghc-8_10_1
+          context: haskell-ci
+          fail-incoherent-builds: false
+          run-check: false
+          binary-cache-uri: ${BINARY_CACHE_URI-"http://hw-binary-cache-us-west-2-a.s3-website-us-west-2.amazonaws.com/archive"}
+          cabal-build-extra: --write-ghc-environment-files=ghc8.4.4+
+          cabal-test-extra: --test-show-details=direct --test-options='+RTS -g1'
+
+      - merge-point/merge-point:
+          name: Build Ok
+          requires:
+            - GHC 8.6.5
+            - GHC 8.8.3
+            - GHC 8.10.1
+
+      - github/release-cabal:
+          name: GitHub Release
+          context: haskell-ci
+          requires:
+            - Build Ok
+          checkout: true
+          filters:
+            branches:
+              only: master
+
+      - hackage/upload:
+          context: haskell-ci
+          publish: true
+          requires:
+            - GitHub Release
+          username: ${HACKAGE_USER}
+          password: ${HACKAGE_PASS}

--- a/cardano-prelude.cabal
+++ b/cardano-prelude.cabal
@@ -6,7 +6,7 @@ license:             MIT
 license-file:        LICENSE
 author:              IOHK
 maintainer:          operations@iohk.io
-copyright:           2018 IOHK
+copyright:           2018-2020 IOHK
 category:            Currency
 build-type:          Simple
 extra-source-files:  ChangeLog.md, README.md cbits/hashset.h cbits/worklist.h
@@ -77,10 +77,11 @@ library
                        -fno-warn-unsafe
                        -fno-warn-safe
   if impl(ghc >=8.8)
-    ghc-options:       -Wno-missing-deriving-strategies
+    ghc-options:       -fno-warn-missing-deriving-strategies
   if impl(ghc >=8.10)
-    ghc-options:       -Wno-prepositive-qualified-module
-                       -Wno-missing-safe-haskell-mode
+    ghc-options:       -fno-warn-missing-safe-haskell-mode
+                       -fno-warn-prepositive-qualified-module
+                       -fno-warn-unused-packages
 
   cc-options:          -Wall
 
@@ -126,8 +127,8 @@ test-suite cardano-prelude-test
                      , QuickCheck
                      , quickcheck-instances
                      , random
-                     , text
                      , template-haskell
+                     , text
                      , time
 
   default-language:    Haskell2010
@@ -137,6 +138,14 @@ test-suite cardano-prelude-test
                        -fno-warn-missing-import-lists
                        -fno-warn-unsafe
                        -fno-warn-safe
+                       -threaded
+                       -rtsopts
+  if impl(ghc >=8.8)
+    ghc-options:       -fno-warn-missing-deriving-strategies
+  if impl(ghc >=8.10)
+    ghc-options:       -fno-warn-missing-safe-haskell-mode
+                       -fno-warn-prepositive-qualified-module
+                       -fno-warn-unused-packages
 
   if (!flag(development))
     ghc-options:         -Werror

--- a/src/Cardano/Prelude/Base.hs
+++ b/src/Cardano/Prelude/Base.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE Safe #-}
 
 module Cardano.Prelude.Base
   ( module X

--- a/test/Test/Cardano/Prelude/GHC/Heap/NormalForm.hs
+++ b/test/Test/Cardano/Prelude/GHC/Heap/NormalForm.hs
@@ -7,7 +7,6 @@ where
 
 import Cardano.Prelude
 
-import Control.Applicative ((<$>))
 import GHC.Exts.Heap
 import Hedgehog
   ( Property

--- a/test/Test/Cardano/Prelude/GHC/Heap/NormalForm/Classy.hs
+++ b/test/Test/Cardano/Prelude/GHC/Heap/NormalForm/Classy.hs
@@ -24,8 +24,6 @@ import GHC.Types (IO (..), Int (..))
 import Prelude (String)
 import System.Random (randomRIO)
 import qualified Data.Text as Text
-
-import Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
 import qualified Data.Sequence.Internal as SI
 

--- a/test/Test/Cardano/Prelude/GHC/Heap/Size.hs
+++ b/test/Test/Cardano/Prelude/GHC/Heap/Size.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE TemplateHaskell            #-}
 
 {-# OPTIONS_GHC -fno-full-laziness #-}
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
 
 module Test.Cardano.Prelude.GHC.Heap.Size (tests) where
 

--- a/test/Test/Cardano/Prelude/GHC/Heap/Tree.hs
+++ b/test/Test/Cardano/Prelude/GHC/Heap/Tree.hs
@@ -9,7 +9,6 @@ where
 
 import Cardano.Prelude
 
-import Control.Applicative ((<$>))
 import Data.Text (unpack)
 import Hedgehog
   ( Gen

--- a/test/Test/Cardano/Prelude/Helpers.hs
+++ b/test/Test/Cardano/Prelude/Helpers.hs
@@ -13,7 +13,6 @@ import Cardano.Prelude
 
 import Data.Data (Data, Constr, toConstr)
 import Formatting (Buildable, build, sformat)
-import GHC.Stack (HasCallStack, withFrozenCallStack)
 
 import Hedgehog (MonadTest, success, (===))
 import Hedgehog.Internal.Property (failWith)

--- a/test/Test/Cardano/Prelude/Orphans.hs
+++ b/test/Test/Cardano/Prelude/Orphans.hs
@@ -1,8 +1,9 @@
-{-# LANGUAGE DeriveFoldable    #-}
-{-# LANGUAGE DeriveFunctor     #-}
-{-# LANGUAGE DeriveTraversable #-}
-{-# LANGUAGE PolyKinds         #-}
-{-# LANGUAGE TypeFamilies      #-}
+{-# LANGUAGE DeriveFoldable     #-}
+{-# LANGUAGE DeriveFunctor      #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DeriveTraversable  #-}
+{-# LANGUAGE PolyKinds          #-}
+{-# LANGUAGE TypeFamilies       #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -21,7 +22,7 @@ import qualified Test.QuickCheck as QC
 
 
 data Five a = Five a a a a a
-    deriving (Functor, Foldable, Traversable)
+    deriving stock (Functor, Foldable, Traversable)
 
 five :: a -> Five a
 five a = Five a a a a a

--- a/test/Test/Cardano/Prelude/QuickCheck/Arbitrary.hs
+++ b/test/Test/Cardano/Prelude/QuickCheck/Arbitrary.hs
@@ -24,7 +24,6 @@ import Cardano.Prelude
 
 import Data.ByteString (pack)
 import qualified Data.ByteString.Lazy as BL (ByteString, pack)
-import Data.List.NonEmpty (NonEmpty((:|)))
 import Formatting (build, sformat)
 import Test.QuickCheck (Arbitrary(..), Gen, listOf, scale, shuffle, vector)
 import Test.QuickCheck.Gen (unGen)

--- a/test/Test/Cardano/Prelude/Tripping.hs
+++ b/test/Test/Cardano/Prelude/Tripping.hs
@@ -23,12 +23,10 @@ import Cardano.Prelude
 
 import Data.Aeson (FromJSON, ToJSON, decode, fromJSON, encode, toJSON)
 import Data.String (String, unlines)
-import Data.Functor.Identity (Identity(..))
 import qualified Data.Map as Map
-import Data.Ord (comparing)
 import Data.Text.Internal.Builder (toLazyText)
 import Formatting.Buildable (Buildable(..))
-import System.IO (hSetEncoding, stderr, stdout, utf8)
+import System.IO (hSetEncoding, utf8)
 import Text.Show.Pretty (Value(..), parseValue)
 import qualified Text.JSON.Canonical as CanonicalJSON
 

--- a/test/cardano-prelude-test.cabal
+++ b/test/cardano-prelude-test.cabal
@@ -57,6 +57,12 @@ library
                        -fno-warn-missing-import-lists
                        -fno-warn-safe
                        -fno-warn-unsafe
+  if impl(ghc >=8.8)
+    ghc-options:       -fno-warn-missing-deriving-strategies
+  if impl(ghc >=8.10)
+    ghc-options:       -fno-warn-missing-safe-haskell-mode
+                       -fno-warn-prepositive-qualified-module
+                       -fno-warn-unused-packages
 
   if (!flag(development))
     ghc-options:         -Werror


### PR DESCRIPTION
This PR is on top of: https://github.com/input-output-hk/cardano-prelude/pull/120

I don't have permission to CircleCI, so I put up a demo in my `haskell-works` account here: https://github.com/haskell-works/cardano-prelude/pull/1

Here is what it looks like in Github:

![image](https://user-images.githubusercontent.com/63014/87738615-23e66880-c821-11ea-9f69-9c80611ee792.png)

This shows the build times (about 2 minutes). https://circleci.com/gh/haskell-works/cardano-prelude/tree/circleci

![image](https://user-images.githubusercontent.com/63014/87738721-6019c900-c821-11ea-9699-373d5bf6163f.png)

Caching of dependencies is per package and can be shared between projects:

![image](https://user-images.githubusercontent.com/63014/87739004-0bc31900-c822-11ea-8cc7-6626d8b72c29.png)

Set up requires an S3 bucket.

Can serve to confirm that builds outside outside of Nix works.

MacOS builds possible.

