### PR TITLE
Compile for ghc 8.8.3 and ghc 8.10.1

### DIFF
--- a/cardano-prelude.cabal
+++ b/cardano-prelude.cabal
@@ -6,7 +6,7 @@ license:             MIT
 license-file:        LICENSE
 author:              IOHK
 maintainer:          operations@iohk.io
-copyright:           2018 IOHK
+copyright:           2018-2020 IOHK
 category:            Currency
 build-type:          Simple
 extra-source-files:  ChangeLog.md, README.md cbits/hashset.h cbits/worklist.h
@@ -77,10 +77,11 @@ library
                        -fno-warn-unsafe
                        -fno-warn-safe
   if impl(ghc >=8.8)
-    ghc-options:       -Wno-missing-deriving-strategies
+    ghc-options:       -fno-warn-missing-deriving-strategies
   if impl(ghc >=8.10)
-    ghc-options:       -Wno-prepositive-qualified-module
-                       -Wno-missing-safe-haskell-mode
+    ghc-options:       -fno-warn-missing-safe-haskell-mode
+                       -fno-warn-prepositive-qualified-module
+                       -fno-warn-unused-packages
 
   cc-options:          -Wall
 
@@ -126,8 +127,8 @@ test-suite cardano-prelude-test
                      , QuickCheck
                      , quickcheck-instances
                      , random
-                     , text
                      , template-haskell
+                     , text
                      , time
 
   default-language:    Haskell2010
@@ -137,6 +138,14 @@ test-suite cardano-prelude-test
                        -fno-warn-missing-import-lists
                        -fno-warn-unsafe
                        -fno-warn-safe
+                       -threaded
+                       -rtsopts
+  if impl(ghc >=8.8)
+    ghc-options:       -fno-warn-missing-deriving-strategies
+  if impl(ghc >=8.10)
+    ghc-options:       -fno-warn-missing-safe-haskell-mode
+                       -fno-warn-prepositive-qualified-module
+                       -fno-warn-unused-packages
 
   if (!flag(development))
     ghc-options:         -Werror

--- a/src/Cardano/Prelude/Base.hs
+++ b/src/Cardano/Prelude/Base.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE Safe #-}
 
 module Cardano.Prelude.Base
   ( module X

--- a/test/Test/Cardano/Prelude/GHC/Heap/NormalForm.hs
+++ b/test/Test/Cardano/Prelude/GHC/Heap/NormalForm.hs
@@ -7,7 +7,6 @@ where
 
 import Cardano.Prelude
 
-import Control.Applicative ((<$>))
 import GHC.Exts.Heap
 import Hedgehog
   ( Property

--- a/test/Test/Cardano/Prelude/GHC/Heap/NormalForm/Classy.hs
+++ b/test/Test/Cardano/Prelude/GHC/Heap/NormalForm/Classy.hs
@@ -24,8 +24,6 @@ import GHC.Types (IO (..), Int (..))
 import Prelude (String)
 import System.Random (randomRIO)
 import qualified Data.Text as Text
-
-import Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
 import qualified Data.Sequence.Internal as SI
 

--- a/test/Test/Cardano/Prelude/GHC/Heap/Size.hs
+++ b/test/Test/Cardano/Prelude/GHC/Heap/Size.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE TemplateHaskell            #-}
 
 {-# OPTIONS_GHC -fno-full-laziness #-}
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
 
 module Test.Cardano.Prelude.GHC.Heap.Size (tests) where
 

--- a/test/Test/Cardano/Prelude/GHC/Heap/Tree.hs
+++ b/test/Test/Cardano/Prelude/GHC/Heap/Tree.hs
@@ -9,7 +9,6 @@ where
 
 import Cardano.Prelude
 
-import Control.Applicative ((<$>))
 import Data.Text (unpack)
 import Hedgehog
   ( Gen

--- a/test/Test/Cardano/Prelude/Helpers.hs
+++ b/test/Test/Cardano/Prelude/Helpers.hs
@@ -13,7 +13,6 @@ import Cardano.Prelude
 
 import Data.Data (Data, Constr, toConstr)
 import Formatting (Buildable, build, sformat)
-import GHC.Stack (HasCallStack, withFrozenCallStack)
 
 import Hedgehog (MonadTest, success, (===))
 import Hedgehog.Internal.Property (failWith)

--- a/test/Test/Cardano/Prelude/Orphans.hs
+++ b/test/Test/Cardano/Prelude/Orphans.hs
@@ -1,8 +1,9 @@
-{-# LANGUAGE DeriveFoldable    #-}
-{-# LANGUAGE DeriveFunctor     #-}
-{-# LANGUAGE DeriveTraversable #-}
-{-# LANGUAGE PolyKinds         #-}
-{-# LANGUAGE TypeFamilies      #-}
+{-# LANGUAGE DeriveFoldable     #-}
+{-# LANGUAGE DeriveFunctor      #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DeriveTraversable  #-}
+{-# LANGUAGE PolyKinds          #-}
+{-# LANGUAGE TypeFamilies       #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
@@ -21,7 +22,7 @@ import qualified Test.QuickCheck as QC
 
 
 data Five a = Five a a a a a
-    deriving (Functor, Foldable, Traversable)
+    deriving stock (Functor, Foldable, Traversable)
 
 five :: a -> Five a
 five a = Five a a a a a

--- a/test/Test/Cardano/Prelude/QuickCheck/Arbitrary.hs
+++ b/test/Test/Cardano/Prelude/QuickCheck/Arbitrary.hs
@@ -24,7 +24,6 @@ import Cardano.Prelude
 
 import Data.ByteString (pack)
 import qualified Data.ByteString.Lazy as BL (ByteString, pack)
-import Data.List.NonEmpty (NonEmpty((:|)))
 import Formatting (build, sformat)
 import Test.QuickCheck (Arbitrary(..), Gen, listOf, scale, shuffle, vector)
 import Test.QuickCheck.Gen (unGen)

--- a/test/Test/Cardano/Prelude/Tripping.hs
+++ b/test/Test/Cardano/Prelude/Tripping.hs
@@ -23,12 +23,10 @@ import Cardano.Prelude
 
 import Data.Aeson (FromJSON, ToJSON, decode, fromJSON, encode, toJSON)
 import Data.String (String, unlines)
-import Data.Functor.Identity (Identity(..))
 import qualified Data.Map as Map
-import Data.Ord (comparing)
 import Data.Text.Internal.Builder (toLazyText)
 import Formatting.Buildable (Buildable(..))
-import System.IO (hSetEncoding, stderr, stdout, utf8)
+import System.IO (hSetEncoding, utf8)
 import Text.Show.Pretty (Value(..), parseValue)
 import qualified Text.JSON.Canonical as CanonicalJSON
 

--- a/test/cardano-prelude-test.cabal
+++ b/test/cardano-prelude-test.cabal
@@ -57,6 +57,12 @@ library
                        -fno-warn-missing-import-lists
                        -fno-warn-safe
                        -fno-warn-unsafe
+  if impl(ghc >=8.8)
+    ghc-options:       -fno-warn-missing-deriving-strategies
+  if impl(ghc >=8.10)
+    ghc-options:       -fno-warn-missing-safe-haskell-mode
+                       -fno-warn-prepositive-qualified-module
+                       -fno-warn-unused-packages
 
   if (!flag(development))
     ghc-options:         -Werror


### PR DESCRIPTION
* Fixes to compile across the following GHCs (continuing from work from https://github.com/input-output-hk/cardano-prelude/pull/114):
  * `ghc-8.6.5`
  * `ghc-8.8.3`
  * `ghc-8.10.1`
* Add `stack.yaml.lock` and `/.vscode` to `.gitignore`

## Multiple GHC build fix details
* Remove unused imports
* Disable warnings that were introduced in new versions of GHC

## Notes
There is currently no CI for `ghc-8.8.3` and `ghc-8.10.1` builds.  These will come in a future PR.