### PR TITLE
Update index-state

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,4 @@
-index-state: 2020-07-15T00:00:00Z
+index-state: 2020-09-15T00:00:00Z
 
 packages:
   ./

--- a/cardano-prelude.cabal
+++ b/cardano-prelude.cabal
@@ -57,7 +57,7 @@ library
                      , hashable
                      , integer-gmp
                      , mtl
-                     , nonempty-containers
+                     , nonempty-containers    >= 0.3.4
                      , protolude
                      , serialise
                      , tagged

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "35b1ec8cd577bfc5abf7d0325f38aab01de5ed00",
-        "sha256": "0mg18i6g7nxd7qk0kaca6k8dsc3kam21772zlr19k03ff67ws55j",
+        "rev": "4f875ebe99c5a068b6276809c8e822e40018935d",
+        "sha256": "05kq921cfnfakdlq23pvmzr4fdm2qanadbsnibwgz267hvi41x6n",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/35b1ec8cd577bfc5abf7d0325f38aab01de5ed00.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/4f875ebe99c5a068b6276809c8e822e40018935d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {
@@ -17,10 +17,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "95f7dfdff554223606f6be266c36eabe81cbe800",
-        "sha256": "05ibcw52jg7q66sd0vqj0fv3zlz7mdrfywys9111n4bj9rd9rl1n",
+        "rev": "83109208047b07d5f0c103c87e6685c61c36a9f6",
+        "sha256": "1wfflfhd3jc8j49kgbvw0absvibkwm77wrjjc9ls8xkrcnprn4l7",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/95f7dfdff554223606f6be266c36eabe81cbe800.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/83109208047b07d5f0c103c87e6685c61c36a9f6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/src/Cardano/Prelude/Orphans.hs
+++ b/src/Cardano/Prelude/Orphans.hs
@@ -10,26 +10,11 @@ module Cardano.Prelude.Orphans
   ()
 where
 
-import Cardano.Prelude.Base
+import           Cardano.Prelude.Base
+import           Data.Tagged          (Tagged (Tagged))
+import           Formatting.Buildable (Buildable (..))
 
-import Data.Aeson (FromJSON(..), ToJSON(..))
-import Data.Set.NonEmpty (NESet)
-import qualified Data.Set.NonEmpty as NES
-import Data.Tagged (Tagged(Tagged))
-import qualified Formatting as F
-import Formatting.Buildable (Buildable(..))
-
-
---------------------------------------------------------------------------------
--- Aeson
---------------------------------------------------------------------------------
-
-instance (Ord a, FromJSON a) => FromJSON (NESet a) where
-  parseJSON = fmap NES.fromList . parseJSON
-
-instance (Ord a, ToJSON a) => ToJSON (NESet a) where
-  toJSON = toJSON . toList
-
+import qualified Formatting           as F
 
 --------------------------------------------------------------------------------
 -- Buildable

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,5 +4,9 @@ packages:
   - .
   - test
 
+extra-deps:
+  - nonempty-containers-0.3.4.0
+  - nonempty-vector-0.2.0.2
+
 nix:
   shell-file: nix/stack-shell.nix


### PR DESCRIPTION
* Update index-state
* Add lower-bounds to nonempty-containers
* Do not define ToJSON/FromJSON instances of `NESet`

The instance fix addresses this error when building with new index-state:

```
src/Cardano/Prelude/Orphans.hs:27:10: error:
    Duplicate instance declarations:
      instance (Ord a, FromJSON a) => FromJSON (NESet a)
        -- Defined at src/Cardano/Prelude/Orphans.hs:27:10
      instance (FromJSON a, Ord a) => FromJSON (NESet a)
        -- Defined in ‘Data.Set.NonEmpty.Internal’
   |
27 | instance (Ord a, FromJSON a) => FromJSON (NESet a) where
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Cardano/Prelude/Orphans.hs:30:10: error:
    Duplicate instance declarations:
      instance (Ord a, ToJSON a) => ToJSON (NESet a)
        -- Defined at src/Cardano/Prelude/Orphans.hs:30:10
      instance ToJSON a => ToJSON (NESet a)
        -- Defined in ‘Data.Set.NonEmpty.Internal’
   |
30 | instance (Ord a, ToJSON a) => ToJSON (NESet a) where
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```