### PR TITLE
Limit base16-bytestring to version lower than 1

### DIFF
--- a/cardano-prelude.cabal
+++ b/cardano-prelude.cabal
@@ -44,7 +44,7 @@ library
   build-depends:       base
                      , aeson
                      , array
-                     , base16-bytestring
+                     , base16-bytestring      < 1
                      , bytestring
                      , canonical-json
                      , cborg


### PR DESCRIPTION
`base16-bytestring-1.0.0.0` changed type of `decode` function form `decode :: ByteString -> (ByteString, ByteString)` to  `decode :: ByteString -> Either String ByteString` so with current implementation isn't possible build prelude with new base16-bytestring