### PR TITLE
Drop support for ghc-8.6.5

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -13,11 +13,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.6.5", "8.10.4"]
+        ghc: ["8.10.4"]
         os: [ubuntu-latest, macos-latest, windows-latest]
-        exclude:
-          - os: windows-latest
-            ghc: 8.6.5
 
     steps:
     - uses: actions/checkout@v1

--- a/cardano-prelude-test/cardano-prelude-test.cabal
+++ b/cardano-prelude-test/cardano-prelude-test.cabal
@@ -1,16 +1,16 @@
 cabal-version: 2.2
 
-name:                cardano-prelude-test
-version:             0.1.0.0
-synopsis:            Utility types and functions for testing Cardano
-description:         Utility types and functions for testing Cardano
-license:             MIT
-license-file:        LICENSE
-author:              IOHK
-maintainer:          operations@iohk.io
-copyright:           2018-2021 IOHK
-category:            Currency
-build-type:          Simple
+name:                 cardano-prelude-test
+version:              0.1.0.0
+synopsis:             Utility types and functions for testing Cardano
+description:          Utility types and functions for testing Cardano
+license:              MIT
+license-file:         LICENSE
+author:               IOHK
+maintainer:           operations@iohk.io
+copyright:            2018-2021 IOHK
+category:             Currency
+build-type:           Simple
 
 flag development
   description: Disable `-Werror`
@@ -18,79 +18,76 @@ flag development
   manual: True
 
 library
-  hs-source-dirs:      src
-  exposed-modules:     Test.Cardano.Prelude
-  other-modules:       Test.Cardano.Prelude.Base16
-                       Test.Cardano.Prelude.Gen
-                       Test.Cardano.Prelude.Golden
-                       Test.Cardano.Prelude.Helpers
-                       Test.Cardano.Prelude.Orphans
-                       Test.Cardano.Prelude.QuickCheck.Arbitrary
-                       Test.Cardano.Prelude.QuickCheck.Property
-                       Test.Cardano.Prelude.Tripping
-  build-depends:       base
-                     , aeson
-                     , aeson-pretty >= 0.8.5
-                     , attoparsec
-                     , base16-bytestring >= 1
-                     , bytestring
-                     , canonical-json
-                     , cardano-prelude
-                     , containers
-                     , cryptonite
-                     , formatting
-                     , hedgehog
-                     , hspec
-                     , pretty-show
-                     , QuickCheck
-                     , quickcheck-instances
-                     , template-haskell
-                     , text
-                     , time
-  default-language:    Haskell2010
-  default-extensions:  NoImplicitPrelude
-  ghc-options:         -Weverything
-                       -fno-warn-missing-import-lists
-                       -fno-warn-safe
-                       -fno-warn-unsafe
-  if impl(ghc >=8.8)
-    ghc-options:       -fno-warn-missing-deriving-strategies
-  if impl(ghc >=8.10)
-    ghc-options:       -fno-warn-missing-safe-haskell-mode
-                       -fno-warn-prepositive-qualified-module
+  hs-source-dirs:     src
+  exposed-modules:    Test.Cardano.Prelude
+  other-modules:      Test.Cardano.Prelude.Base16
+                      Test.Cardano.Prelude.Gen
+                      Test.Cardano.Prelude.Golden
+                      Test.Cardano.Prelude.Helpers
+                      Test.Cardano.Prelude.Orphans
+                      Test.Cardano.Prelude.QuickCheck.Arbitrary
+                      Test.Cardano.Prelude.QuickCheck.Property
+                      Test.Cardano.Prelude.Tripping
+  build-depends:      base
+                    , aeson
+                    , aeson-pretty >= 0.8.5
+                    , attoparsec
+                    , base16-bytestring >= 1
+                    , bytestring
+                    , canonical-json
+                    , cardano-prelude
+                    , containers
+                    , cryptonite
+                    , formatting
+                    , hedgehog
+                    , hspec
+                    , pretty-show
+                    , QuickCheck
+                    , quickcheck-instances
+                    , template-haskell
+                    , text
+                    , time
+  default-language:   Haskell2010
+  default-extensions: NoImplicitPrelude
+  ghc-options:        -Weverything
+                      -fno-warn-all-missed-specialisations
+                      -fno-warn-missing-deriving-strategies
+                      -fno-warn-missing-import-lists
+                      -fno-warn-missing-safe-haskell-mode
+                      -fno-warn-prepositive-qualified-module
+                      -fno-warn-safe
+                      -fno-warn-unsafe
 
   if (!flag(development))
-    ghc-options:         -Werror
+    ghc-options:      -Werror
 
 test-suite cardano-prelude-test-suite
-  hs-source-dirs:      test
-  main-is:             test.hs
-  type:                exitcode-stdio-1.0
-  other-modules:       Test.Cardano.Prelude.GHC.Heap.NormalFormSpec
-                       Test.Cardano.Prelude.GHC.Heap.SizeSpec
-                       Test.Cardano.Prelude.GHC.Heap.TreeSpec
+  hs-source-dirs:     test
+  main-is:            test.hs
+  type:               exitcode-stdio-1.0
+  other-modules:      Test.Cardano.Prelude.GHC.Heap.NormalFormSpec
+                      Test.Cardano.Prelude.GHC.Heap.SizeSpec
+                      Test.Cardano.Prelude.GHC.Heap.TreeSpec
 
-  build-depends:       base
-                     , bytestring
-                     , cardano-prelude
-                     , cardano-prelude-test
-                     , ghc-heap
-                     , ghc-prim
-                     , hedgehog
-                     , text
-  default-language:    Haskell2010
-  default-extensions:  NoImplicitPrelude
-  ghc-options:         -Weverything
-                       -fno-warn-missing-import-lists
-                       -fno-warn-unsafe
-                       -fno-warn-safe
-                       -threaded
-                       -rtsopts
-  if impl(ghc >=8.8)
-    ghc-options:       -fno-warn-missing-deriving-strategies
-  if impl(ghc >=8.10)
-    ghc-options:       -fno-warn-missing-safe-haskell-mode
-                       -fno-warn-prepositive-qualified-module
+  build-depends:      base
+                    , bytestring
+                    , cardano-prelude
+                    , cardano-prelude-test
+                    , ghc-heap
+                    , ghc-prim
+                    , hedgehog
+                    , text
+  default-language:   Haskell2010
+  default-extensions: NoImplicitPrelude
+  ghc-options:        -Weverything
+                      -fno-warn-missing-import-lists
+                      -fno-warn-unsafe
+                      -fno-warn-safe
+                      -threaded
+                      -rtsopts
+                      -fno-warn-missing-deriving-strategies
+                      -fno-warn-missing-safe-haskell-mode
+                      -fno-warn-prepositive-qualified-module
 
   if (!flag(development))
-    ghc-options:       -Werror
+    ghc-options:      -Werror

--- a/cardano-prelude/cardano-prelude.cabal
+++ b/cardano-prelude/cardano-prelude.cabal
@@ -1,17 +1,17 @@
 cabal-version: 2.2
 
-name:                cardano-prelude
-version:             0.1.0.0
-synopsis:            A Prelude replacement for the Cardano project
-description:         A Prelude replacement for the Cardano project
-license:             MIT
-license-file:        LICENSE
-author:              IOHK
-maintainer:          operations@iohk.io
-copyright:           2018-2021 IOHK
-category:            Currency
-build-type:          Simple
-extra-source-files:  ChangeLog.md, README.md cbits/hashset.h cbits/worklist.h
+name:                 cardano-prelude
+version:              0.1.0.0
+synopsis:             A Prelude replacement for the Cardano project
+description:          A Prelude replacement for the Cardano project
+license:              MIT
+license-file:         LICENSE
+author:               IOHK
+maintainer:           operations@iohk.io
+copyright:            2018-2021 IOHK
+category:             Currency
+build-type:           Simple
+extra-source-files:   ChangeLog.md, README.md cbits/hashset.h cbits/worklist.h
 
 flag development
   description: Disable `-Werror`
@@ -19,61 +19,59 @@ flag development
   manual: True
 
 library
-  hs-source-dirs:      src
-  exposed-modules:     Cardano.Prelude
-                       Data.FingerTree.Strict
-                       Data.Sequence.Strict
-                       Data.Semigroup.Action
-  other-modules:       Cardano.Prelude.Base
-                       Cardano.Prelude.Error
-                       Cardano.Prelude.Formatting
-                       Cardano.Prelude.GHC.Heap
-                       Cardano.Prelude.GHC.Heap.NormalForm
-                       Cardano.Prelude.GHC.Heap.Size
-                       Cardano.Prelude.GHC.Heap.Tree
-                       Cardano.Prelude.HeapWords
-                       Cardano.Prelude.Json.Canonical
-                       Cardano.Prelude.Json.Parse
-                       Cardano.Prelude.Orphans
-                       Cardano.Prelude.Strict
+  hs-source-dirs:     src
+  exposed-modules:    Cardano.Prelude
+                      Data.FingerTree.Strict
+                      Data.Sequence.Strict
+                      Data.Semigroup.Action
+  other-modules:      Cardano.Prelude.Base
+                      Cardano.Prelude.Error
+                      Cardano.Prelude.Formatting
+                      Cardano.Prelude.GHC.Heap
+                      Cardano.Prelude.GHC.Heap.NormalForm
+                      Cardano.Prelude.GHC.Heap.Size
+                      Cardano.Prelude.GHC.Heap.Tree
+                      Cardano.Prelude.HeapWords
+                      Cardano.Prelude.Json.Canonical
+                      Cardano.Prelude.Json.Parse
+                      Cardano.Prelude.Orphans
+                      Cardano.Prelude.Strict
 
-  build-depends:       base
-                     , aeson
-                     , array
-                     , base16-bytestring >= 1
-                     , bytestring
-                     , canonical-json
-                     , cborg
-                     , containers
-                     , fingertree
-                     , formatting
-                     , ghc-heap
-                     , ghc-prim
-                     , integer-gmp
-                     , mtl
-                     , nothunks
-                     , protolude
-                     , serialise
-                     , tagged
-                     , text
-                     , time
-                     , vector
-  default-language:    Haskell2010
-  default-extensions:  NoImplicitPrelude
-  c-sources:           cbits/hashset.c
-                       cbits/worklist.c
-                       cbits/closure_size.c
-  ghc-options:         -Weverything
-                       -fno-warn-missing-import-lists
-                       -fno-warn-unsafe
-                       -fno-warn-safe
-  if impl(ghc >=8.8)
-    ghc-options:       -fno-warn-missing-deriving-strategies
-  if impl(ghc >=8.10)
-    ghc-options:       -fno-warn-missing-safe-haskell-mode
-                       -fno-warn-prepositive-qualified-module
-
-  cc-options:          -Wall
+  build-depends:      base               >= 4.14       && < 4.15
+                    , aeson
+                    , array
+                    , base16-bytestring  >= 1
+                    , bytestring
+                    , canonical-json
+                    , cborg
+                    , containers
+                    , fingertree
+                    , formatting
+                    , ghc-heap
+                    , ghc-prim
+                    , integer-gmp
+                    , mtl
+                    , nothunks
+                    , protolude
+                    , serialise
+                    , tagged
+                    , text
+                    , time
+                    , vector
+  default-language:   Haskell2010
+  default-extensions: NoImplicitPrelude
+  c-sources:          cbits/hashset.c
+                      cbits/worklist.c
+                      cbits/closure_size.c
+  ghc-options:        -Weverything
+                      -fno-warn-all-missed-specialisations
+                      -fno-warn-missing-deriving-strategies
+                      -fno-warn-missing-import-lists
+                      -fno-warn-missing-safe-haskell-mode
+                      -fno-warn-prepositive-qualified-module
+                      -fno-warn-safe
+                      -fno-warn-unsafe
+  cc-options:         -Wall
 
   if (!flag(development))
-    ghc-options:       -Werror
+    ghc-options:      -Werror


### PR DESCRIPTION
* Add lower-bounds to `base`.
* Remove redundant `if` conditionals from cabal files.
* Tidy up cabal files.
* Suppress spurious `all-missed-specialisations` warnings.
* Temporarily drop back to `ghc-8.10.3` from `ghc-8.10.4` to work around GHC installation issues in Github Actions