### PR TITLE
Remove upper bound on protolude

### DIFF
--- a/cardano-prelude/cardano-prelude.cabal
+++ b/cardano-prelude/cardano-prelude.cabal
@@ -49,7 +49,7 @@ library
                     , ghc-prim
                     , integer-gmp
                     , mtl
-                    , protolude < 0.3.2
+                    , protolude
                     , tagged
                     , text
                     , time

--- a/cardano-prelude/src/Cardano/Prelude.hs
+++ b/cardano-prelude/src/Cardano/Prelude.hs
@@ -3,7 +3,8 @@ module Cardano.Prelude
   )
 where
 
-import Cardano.Prelude.Base as X
+import Cardano.Prelude.Base as X hiding (readEither)
+import Cardano.Prelude.Compat as X (readEither)
 import Cardano.Prelude.Error as X
 import Cardano.Prelude.Formatting as X
 import Cardano.Prelude.GHC.Heap as X


### PR DESCRIPTION
There was a breaking change to the `readEither` function from `protolude-0.3.0` to `protolude-0.3.1`.

This change exports a version of `readEither` as defined in `protolude-0.3.1` onwards so that downstream projects can use that version of `readEither` regardless of which version of `protolude` is used as the dependency.

This allows downstream projects upgrade to not care which version of `protolude` is pulled in as a dependency.