### PR TITLE
New cardano-tasty-hegehog package

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -3,6 +3,7 @@ index-state: 2022-09-21T00:00:00Z
 packages:
   cardano-prelude
   cardano-prelude-test
+  cardano-tasty-hedgehog
 
 constraints:
   -- Only this supports ghc-9.2

--- a/cardano-tasty-hedgehog/LICENSE
+++ b/cardano-tasty-hedgehog/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2018-2021 IOHK
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to
+do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/cardano-tasty-hedgehog/cardano-tasty-hedgehog.cabal
+++ b/cardano-tasty-hedgehog/cardano-tasty-hedgehog.cabal
@@ -1,0 +1,39 @@
+cabal-version: 2.2
+
+name:                 cardano-tasty-hedgehog
+version:              0.1.0.0
+synopsis:             Compatibility shim for tasty breakages
+description:          Compatibility shim for tasty breakages.
+license:              MIT
+license-file:         LICENSE
+author:               IOHK
+maintainer:           operations@iohk.io
+copyright:            2018-2022 IOHK
+category:             Currency
+build-type:           Simple
+
+flag development
+  description: Disable `-Werror`
+  default: False
+  manual: True
+
+library
+  hs-source-dirs:     src
+  exposed-modules:    Test.Cardano.Tasty.Hedgehog
+  build-depends:      base
+                    , hedgehog
+                    , tasty
+                    , tasty-hedgehog
+  default-language:   Haskell2010
+  default-extensions: NoImplicitPrelude
+  ghc-options:        -Weverything
+                      -fno-warn-all-missed-specialisations
+                      -fno-warn-missing-deriving-strategies
+                      -fno-warn-missing-import-lists
+                      -fno-warn-missing-safe-haskell-mode
+                      -fno-warn-prepositive-qualified-module
+                      -fno-warn-safe
+                      -fno-warn-unsafe
+
+  if (!flag(development))
+    ghc-options:      -Werror

--- a/cardano-tasty-hedgehog/src/Test/Cardano/Tasty/Hedgehog.hs
+++ b/cardano-tasty-hedgehog/src/Test/Cardano/Tasty/Hedgehog.hs
@@ -1,0 +1,12 @@
+module Test.Cardano.Tasty.Hedgehog
+  ( testProperty
+  ) where
+
+import Data.String (IsString(..))
+import Test.Tasty (TestName, TestTree)
+import Hedgehog (Property)
+
+import qualified Test.Tasty.Hedgehog as TH
+
+testProperty :: TestName -> Property -> TestTree
+testProperty testName = TH.testPropertyNamed testName (fromString testName)


### PR DESCRIPTION
In newer versions of `tasty-hedgehog`, `testProperty` is deprecated.  This breaks builds.

The new package defines the `testProperty` function to be use temporarily until use sites can switch to something else.

