### PR TITLE
Support both ghc-8.10 and ghc-9.2

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.10.7"]
+        ghc: ["8.10.7", "9.2.4"]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
@@ -23,7 +23,7 @@ jobs:
       id: setup-haskell
       with:
         ghc-version: ${{ matrix.ghc }}
-        cabal-version: 3.4.0.0
+        cabal-version: 3.6.2.0
 
     - name: Haskell versions
       run: |

--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,9 @@
-index-state: 2022-07-01T00:00:00Z
+index-state: 2022-09-21T00:00:00Z
 
 packages:
   cardano-prelude
   cardano-prelude-test
+
+constraints:
+  -- Only this supports ghc-9.2
+  canonical-json >= 0.6.0.1

--- a/cardano-prelude-test/cardano-prelude-test.cabal
+++ b/cardano-prelude-test/cardano-prelude-test.cabal
@@ -55,8 +55,13 @@ library
 
   if (!flag(development))
     ghc-options:      -Werror
-
-test-suite cardano-prelude-test-suite
+ 
+-- NOTE: We need to keep the test-suite name short.
+--       If it's too long, we may exceed the path length
+--       on windows... somehow.
+-- => Keep the test-suite name short (and module names as well)
+--    to make this build on windows.
+test-suite prelude-tests
   hs-source-dirs:     test
   main-is:            test.hs
   type:               exitcode-stdio-1.0

--- a/cardano-prelude-test/cardano-prelude-test.cabal
+++ b/cardano-prelude-test/cardano-prelude-test.cabal
@@ -28,6 +28,7 @@ library
                       Test.Cardano.Prelude.QuickCheck.Arbitrary
                       Test.Cardano.Prelude.QuickCheck.Property
                       Test.Cardano.Prelude.Tripping
+
   build-depends:      base
                     , aeson
                     , aeson-pretty >= 0.8.5
@@ -45,18 +46,12 @@ library
                     , QuickCheck
                     , quickcheck-instances
                     , template-haskell
+                    , th-compat
                     , text
                     , time
   default-language:   Haskell2010
   default-extensions: NoImplicitPrelude
-  ghc-options:        -Weverything
-                      -fno-warn-all-missed-specialisations
-                      -fno-warn-missing-deriving-strategies
-                      -fno-warn-missing-import-lists
-                      -fno-warn-missing-safe-haskell-mode
-                      -fno-warn-prepositive-qualified-module
-                      -fno-warn-safe
-                      -fno-warn-unsafe
+  ghc-options:        -Wall
 
   if (!flag(development))
     ghc-options:      -Werror
@@ -79,15 +74,9 @@ test-suite cardano-prelude-test-suite
                     , text
   default-language:   Haskell2010
   default-extensions: NoImplicitPrelude
-  ghc-options:        -Weverything
-                      -fno-warn-missing-import-lists
-                      -fno-warn-unsafe
-                      -fno-warn-safe
-                      -threaded
+  ghc-options:        -threaded
                       -rtsopts
-                      -fno-warn-missing-deriving-strategies
-                      -fno-warn-missing-safe-haskell-mode
-                      -fno-warn-prepositive-qualified-module
+                      -Wall
 
   if (!flag(development))
     ghc-options:      -Werror

--- a/cardano-prelude/cardano-prelude.cabal
+++ b/cardano-prelude/cardano-prelude.cabal
@@ -35,7 +35,7 @@ library
                       Cardano.Prelude.Orphans
                       Cardano.Prelude.Strict
 
-  build-depends:      base               >= 4.14       && < 4.15
+  build-depends:      base               >= 4.14       && < 4.18
                     , aeson
                     , base16-bytestring  >= 1
                     , bytestring
@@ -56,14 +56,8 @@ library
   c-sources:          cbits/hashset.c
                       cbits/worklist.c
                       cbits/closure_size.c
-  ghc-options:        -Weverything
-                      -fno-warn-all-missed-specialisations
-                      -fno-warn-missing-deriving-strategies
-                      -fno-warn-missing-import-lists
-                      -fno-warn-missing-safe-haskell-mode
-                      -fno-warn-prepositive-qualified-module
-                      -fno-warn-safe
-                      -fno-warn-unsafe
+  ghc-options:        -Wall
+
   cc-options:         -Wall
 
   if (!flag(development))

--- a/cardano-prelude/cardano-prelude.cabal
+++ b/cardano-prelude/cardano-prelude.cabal
@@ -24,6 +24,7 @@ library
                       Data.Semigroup.Action
   other-modules:      Cardano.Prelude.Base
                       Cardano.Prelude.Compat
+                      Cardano.Prelude.Compat.ByteString.Short
                       Cardano.Prelude.Error
                       Cardano.Prelude.Formatting
                       Cardano.Prelude.GHC.Heap

--- a/cardano-prelude/cardano-prelude.cabal
+++ b/cardano-prelude/cardano-prelude.cabal
@@ -32,6 +32,7 @@ library
                       Cardano.Prelude.GHC.Heap.Tree
                       Cardano.Prelude.Json.Canonical
                       Cardano.Prelude.Json.Parse
+                      Cardano.Prelude.Microlens
                       Cardano.Prelude.Orphans
                       Cardano.Prelude.Strict
 
@@ -46,6 +47,7 @@ library
                     , ghc-heap
                     , ghc-prim
                     , integer-gmp
+                    , microlens
                     , mtl
                     , protolude
                     , tagged

--- a/cardano-prelude/src/Cardano/Prelude.hs
+++ b/cardano-prelude/src/Cardano/Prelude.hs
@@ -5,6 +5,7 @@ where
 
 import Cardano.Prelude.Base as X hiding (readEither)
 import Cardano.Prelude.Compat as X (readEither)
+import Cardano.Prelude.Compat.ByteString.Short as X
 import Cardano.Prelude.Error as X
 import Cardano.Prelude.Formatting as X
 import Cardano.Prelude.GHC.Heap as X

--- a/cardano-prelude/src/Cardano/Prelude.hs
+++ b/cardano-prelude/src/Cardano/Prelude.hs
@@ -10,5 +10,6 @@ import Cardano.Prelude.Formatting as X
 import Cardano.Prelude.GHC.Heap as X
 import Cardano.Prelude.Json.Canonical as X
 import Cardano.Prelude.Json.Parse as X
+import Cardano.Prelude.Microlens as X ()
 import Cardano.Prelude.Orphans ()
 import Cardano.Prelude.Strict as X

--- a/cardano-prelude/src/Cardano/Prelude/Compat/ByteString/Short.hs
+++ b/cardano-prelude/src/Cardano/Prelude/Compat/ByteString/Short.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE MagicHash #-}
+
+module Cardano.Prelude.Compat.ByteString.Short
+  ( unsafeShortByteStringIndex
+  ) where
+
+-- GHC >= 9.0 does not export unsafeIndex for ShortByteString
+-- GHC < 9.0 does not export the ShortByteString constructor SBS.
+-- Coniditional compile to work around this.
+
+#if __GLASGW_HASKELL__ >= 900
+import Data.ByteString.Short (ShortByteString(..))
+import Data.Int (Int)
+import Data.Word (Word8)
+import GHC.Exts (indexWord8Array#)
+
+unsafeShortByteStringIndex :: ShortByteString -> Int -> Word8
+unsafeShortByteStringIndex (SBS ba#) (I# i#) = W8# (indexWord8Array# ba# i#)
+
+#else
+
+import Data.ByteString.Short (ShortByteString, index)
+import Data.Int (Int)
+import Data.Word (Word8)
+
+unsafeShortByteStringIndex :: ShortByteString -> Int -> Word8
+unsafeShortByteStringIndex = index
+
+#endif

--- a/cardano-prelude/src/Cardano/Prelude/Microlens.hs
+++ b/cardano-prelude/src/Cardano/Prelude/Microlens.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Cardano.Prelude.Microlens
+  () where
+
+import Data.Functor ((<$>))
+import Lens.Micro.Internal (Field1(..), Field2(..), Field3(..), Field4(..), Field5(..))
+
+instance Field1 (a, b, c, d, e, f) (a', b, c, d, e, f) a a' where
+  _1 k ~(a, b, c, d, e, f) = (\a' -> (a', b, c, d, e, f)) <$> k a
+  {-# INLINE _1 #-}
+
+instance Field1 (a, b, c, d, e, f, g) (a', b, c, d, e, f, g) a a' where
+  _1 k ~(a, b, c, d, e, f, g) = (\a' -> (a', b, c, d, e, f, g)) <$> k a
+  {-# INLINE _1 #-}
+
+instance Field1 (a, b, c, d, e, f, g, h) (a', b, c, d, e, f, g, h) a a' where
+  _1 k ~(a, b, c, d, e, f, g, h) = (\a' -> (a', b, c, d, e, f, g, h)) <$> k a
+  {-# INLINE _1 #-}
+
+instance Field1 (a, b, c, d, e, f, g, h, i) (a', b, c, d, e, f, g, h, i) a a' where
+  _1 k ~(a, b, c, d, e, f, g, h, i) = (\a' -> (a', b, c, d, e, f, g, h, i)) <$> k a
+  {-# INLINE _1 #-}
+
+instance Field2 (a, b, c, d, e, f) (a, b', c, d, e, f) b b' where
+  _2 k ~(a, b, c, d, e, f) = (\b' -> (a, b', c, d, e, f)) <$> k b
+  {-# INLINE _2 #-}
+
+instance Field2 (a, b, c, d, e, f, g) (a, b', c, d, e, f, g) b b' where
+  _2 k ~(a, b, c, d, e, f, g) = (\b' -> (a, b', c, d, e, f, g)) <$> k b
+  {-# INLINE _2 #-}
+
+instance Field2 (a, b, c, d, e, f, g, h) (a, b', c, d, e, f, g, h) b b' where
+  _2 k ~(a, b, c, d, e, f, g, h) = (\b' -> (a, b', c, d, e, f, g, h)) <$> k b
+  {-# INLINE _2 #-}
+
+instance Field2 (a, b, c, d, e, f, g, h, i) (a, b', c, d, e, f, g, h, i) b b' where
+  _2 k ~(a, b, c, d, e, f, g, h, i) = (\b' -> (a, b', c, d, e, f, g, h, i)) <$> k b
+  {-# INLINE _2 #-}
+
+instance Field3 (a, b, c, d, e, f) (a, b, c', d, e, f) c c' where
+  _3 k ~(a, b, c, d, e, f) = (\c' -> (a, b, c', d, e, f)) <$> k c
+  {-# INLINE _3 #-}
+
+instance Field3 (a, b, c, d, e, f, g) (a, b, c', d, e, f, g) c c' where
+  _3 k ~(a, b, c, d, e, f, g) = (\c' -> (a, b, c', d, e, f, g)) <$> k c
+  {-# INLINE _3 #-}
+
+instance Field3 (a, b, c, d, e, f, g, h) (a, b, c', d, e, f, g, h) c c' where
+  _3 k ~(a, b, c, d, e, f, g, h) = (\c' -> (a, b, c', d, e, f, g, h)) <$> k c
+  {-# INLINE _3 #-}
+
+instance Field3 (a, b, c, d, e, f, g, h, i) (a, b, c', d, e, f, g, h, i) c c' where
+  _3 k ~(a, b, c, d, e, f, g, h, i) = (\c' -> (a, b, c', d, e, f, g, h, i)) <$> k c
+  {-# INLINE _3 #-}
+
+instance Field4 (a, b, c, d, e, f) (a, b, c, d', e, f) d d' where
+  _4 k ~(a, b, c, d, e, f) = (\d' -> (a, b, c, d', e, f)) <$> k d
+  {-# INLINE _4 #-}
+
+instance Field4 (a, b, c, d, e, f, g) (a, b, c, d', e, f, g) d d' where
+  _4 k ~(a, b, c, d, e, f, g) = (\d' -> (a, b, c, d', e, f, g)) <$> k d
+  {-# INLINE _4 #-}
+
+instance Field4 (a, b, c, d, e, f, g, h) (a, b, c, d', e, f, g, h) d d' where
+  _4 k ~(a, b, c, d, e, f, g, h) = (\d' -> (a, b, c, d', e, f, g, h)) <$> k d
+  {-# INLINE _4 #-}
+
+instance Field4 (a, b, c, d, e, f, g, h, i) (a, b, c, d', e, f, g, h, i) d d' where
+  _4 k ~(a, b, c, d, e, f, g, h, i) = (\d' -> (a, b, c, d', e, f, g, h, i)) <$> k d
+  {-# INLINE _4 #-}
+
+instance Field5 (a, b, c, d, e, f) (a, b, c, d, e', f) e e' where
+  _5 k ~(a, b, c, d, e, f) = (\e' -> (a, b, c, d, e', f)) <$> k e
+  {-# INLINE _5 #-}
+
+instance Field5 (a, b, c, d, e, f, g) (a, b, c, d, e', f, g) e e' where
+  _5 k ~(a, b, c, d, e, f, g) = (\e' -> (a, b, c, d, e', f, g)) <$> k e
+  {-# INLINE _5 #-}
+
+instance Field5 (a, b, c, d, e, f, g, h) (a, b, c, d, e', f, g, h) e e' where
+  _5 k ~(a, b, c, d, e, f, g, h) = (\e' -> (a, b, c, d, e', f, g, h)) <$> k e
+  {-# INLINE _5 #-}
+
+instance Field5 (a, b, c, d, e, f, g, h, i) (a, b, c, d, e', f, g, h, i) e e' where
+  _5 k ~(a, b, c, d, e, f, g, h, i) = (\e' -> (a, b, c, d, e', f, g, h, i)) <$> k e
+  {-# INLINE _5 #-}

--- a/default.nix
+++ b/default.nix
@@ -17,7 +17,7 @@ let
 
   haskellPackages = recRecurseIntoAttrs
     # we are only interested in listing the project packages:
-    (selectProjectPackages cardanoPreludeHaskellPackages);
+    (selectProjectPackages cardanoPreludeHaskellPackages.hsPkgs);
 
   self = {
     inherit haskellPackages check-hydra;
@@ -31,7 +31,7 @@ let
 
     checks = recurseIntoAttrs {
       # `checks.tests` collect results of executing the tests:
-      tests = collectChecks haskellPackages;
+      tests = collectChecks' haskellPackages;
     };
 
     shell = import ./shell.nix {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "3e46b71d6ac7808cd3d95408f52eab2fc44a5684",
-        "sha256": "0mm048cg2izm92firqxigknsj9x41i6142zwskx261h38fvzx521",
+        "rev": "95b9f13d13c4d14c6534e442080a7d88301d1ec6",
+        "sha256": "1m3rrgxlc2d6pn6vm09b4ky2nmcad6g7qzl0hgv28q312ppk2bhk",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/3e46b71d6ac7808cd3d95408f52eab2fc44a5684.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/95b9f13d13c4d14c6534e442080a7d88301d1ec6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {
@@ -24,15 +24,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "nixpkgs-21.11-darwin",
+        "branch": "nixpkgs-22.05-darwin",
         "description": "Nix Packages collection",
         "homepage": null,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "573603b7fdb9feb0eb8efc16ee18a015c667ab1b",
-        "sha256": "1z7mxyw5yk1gcsjs5wl8zm4klxg4xngljgrsnpl579l998205qym",
+        "rev": "549d82bdd40f760a438c3c3497c1c61160f3de55",
+        "sha256": "1rk9rh2ssp6zwqbnxa2cyncwjky9igkj90qdgbhzshwwxp89y6ai",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/573603b7fdb9feb0eb8efc16ee18a015c667ab1b.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/549d82bdd40f760a438c3c3497c1c61160f3de55.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -6,57 +6,63 @@ let
   # The fetchers. fetch_<type> fetches specs of type <type>.
   #
 
-  fetch_file = pkgs: spec:
-    if spec.builtin or true then
-      builtins_fetchurl { inherit (spec) url sha256; }
-    else
-      pkgs.fetchurl { inherit (spec) url sha256; };
+  fetch_file = pkgs: name: spec:
+    let
+      name' = sanitizeName name + "-src";
+    in
+      if spec.builtin or true then
+        builtins_fetchurl { inherit (spec) url sha256; name = name'; }
+      else
+        pkgs.fetchurl { inherit (spec) url sha256; name = name'; };
 
   fetch_tarball = pkgs: name: spec:
     let
-      ok = str: ! builtins.isNull (builtins.match "[a-zA-Z0-9+-._?=]" str);
-      # sanitize the name, though nix will still fail if name starts with period
-      name' = stringAsChars (x: if ! ok x then "-" else x) "${name}-src";
+      name' = sanitizeName name + "-src";
     in
       if spec.builtin or true then
         builtins_fetchTarball { name = name'; inherit (spec) url sha256; }
       else
         pkgs.fetchzip { name = name'; inherit (spec) url sha256; };
 
-  fetch_git = spec:
-    builtins.fetchGit { url = spec.repo; inherit (spec) rev ref; };
+  fetch_git = name: spec:
+    let
+      ref =
+        if spec ? ref then spec.ref else
+          if spec ? branch then "refs/heads/${spec.branch}" else
+            if spec ? tag then "refs/tags/${spec.tag}" else
+              abort "In git source '${name}': Please specify `ref`, `tag` or `branch`!";
+    in
+      builtins.fetchGit { url = spec.repo; inherit (spec) rev; inherit ref; };
 
-  fetch_builtin-tarball = spec:
-    builtins.trace
-      ''
-        WARNING:
-          The niv type "builtin-tarball" will soon be deprecated. You should
-          instead use `builtin = true`.
+  fetch_local = spec: spec.path;
 
-          $ niv modify <package> -a type=tarball -a builtin=true
-      ''
-      builtins_fetchTarball { inherit (spec) url sha256; };
+  fetch_builtin-tarball = name: throw
+    ''[${name}] The niv type "builtin-tarball" is deprecated. You should instead use `builtin = true`.
+        $ niv modify ${name} -a type=tarball -a builtin=true'';
 
-  fetch_builtin-url = spec:
-    builtins.trace
-      ''
-        WARNING:
-          The niv type "builtin-url" will soon be deprecated. You should
-          instead use `builtin = true`.
-
-          $ niv modify <package> -a type=file -a builtin=true
-      ''
-      (builtins_fetchurl { inherit (spec) url sha256; });
+  fetch_builtin-url = name: throw
+    ''[${name}] The niv type "builtin-url" will soon be deprecated. You should instead use `builtin = true`.
+        $ niv modify ${name} -a type=file -a builtin=true'';
 
   #
   # Various helpers
   #
 
+  # https://github.com/NixOS/nixpkgs/pull/83241/files#diff-c6f540a4f3bfa4b0e8b6bafd4cd54e8bR695
+  sanitizeName = name:
+    (
+      concatMapStrings (s: if builtins.isList s then "-" else s)
+        (
+          builtins.split "[^[:alnum:]+._?=-]+"
+            ((x: builtins.elemAt (builtins.match "\\.*(.*)" x) 0) name)
+        )
+    );
+
   # The set of packages used when specs are fetched using non-builtins.
-  mkPkgs = sources:
+  mkPkgs = sources: system:
     let
       sourcesNixpkgs =
-        import (builtins_fetchTarball { inherit (sources.nixpkgs) url sha256; }) {};
+        import (builtins_fetchTarball { inherit (sources.nixpkgs) url sha256; }) { inherit system; };
       hasNixpkgsPath = builtins.any (x: x.prefix == "nixpkgs") builtins.nixPath;
       hasThisAsNixpkgsPath = <nixpkgs> == ./.;
     in
@@ -76,13 +82,26 @@ let
 
     if ! builtins.hasAttr "type" spec then
       abort "ERROR: niv spec ${name} does not have a 'type' attribute"
-    else if spec.type == "file" then fetch_file pkgs spec
+    else if spec.type == "file" then fetch_file pkgs name spec
     else if spec.type == "tarball" then fetch_tarball pkgs name spec
-    else if spec.type == "git" then fetch_git spec
+    else if spec.type == "git" then fetch_git name spec
+    else if spec.type == "local" then fetch_local spec
     else if spec.type == "builtin-tarball" then fetch_builtin-tarball name
     else if spec.type == "builtin-url" then fetch_builtin-url name
     else
       abort "ERROR: niv spec ${name} has unknown type ${builtins.toJSON spec.type}";
+
+  # If the environment variable NIV_OVERRIDE_${name} is set, then use
+  # the path directly as opposed to the fetched source.
+  replace = name: drv:
+    let
+      saneName = stringAsChars (c: if isNull (builtins.match "[a-zA-Z0-9]" c) then "_" else c) name;
+      ersatz = builtins.getEnv "NIV_OVERRIDE_${saneName}";
+    in
+      if ersatz == "" then drv else
+        # this turns the string into an actual Nix path (for both absolute and
+        # relative paths)
+        if builtins.substring 0 1 ersatz == "/" then /. + ersatz else /. + builtins.getEnv "PWD" + "/${ersatz}";
 
   # Ports of functions for older nix versions
 
@@ -100,25 +119,29 @@ let
 
   # https://github.com/NixOS/nixpkgs/blob/0258808f5744ca980b9a1f24fe0b1e6f0fecee9c/lib/strings.nix#L269
   stringAsChars = f: s: concatStrings (map f (stringToCharacters s));
+  concatMapStrings = f: list: concatStrings (map f list);
   concatStrings = builtins.concatStringsSep "";
 
+  # https://github.com/NixOS/nixpkgs/blob/8a9f58a375c401b96da862d969f66429def1d118/lib/attrsets.nix#L331
+  optionalAttrs = cond: as: if cond then as else {};
+
   # fetchTarball version that is compatible between all the versions of Nix
-  builtins_fetchTarball = { url, name, sha256 }@attrs:
+  builtins_fetchTarball = { url, name ? null, sha256 }@attrs:
     let
       inherit (builtins) lessThan nixVersion fetchTarball;
     in
       if lessThan nixVersion "1.12" then
-        fetchTarball { inherit name url; }
+        fetchTarball ({ inherit url; } // (optionalAttrs (!isNull name) { inherit name; }))
       else
         fetchTarball attrs;
 
   # fetchurl version that is compatible between all the versions of Nix
-  builtins_fetchurl = { url, sha256 }@attrs:
+  builtins_fetchurl = { url, name ? null, sha256 }@attrs:
     let
       inherit (builtins) lessThan nixVersion fetchurl;
     in
       if lessThan nixVersion "1.12" then
-        fetchurl { inherit url; }
+        fetchurl ({ inherit url; } // (optionalAttrs (!isNull name) { inherit name; }))
       else
         fetchurl attrs;
 
@@ -130,14 +153,15 @@ let
         then abort
           "The values in sources.json should not have an 'outPath' attribute"
         else
-          spec // { outPath = fetch config.pkgs name spec; }
+          spec // { outPath = replace name (fetch config.pkgs name spec); }
     ) config.sources;
 
   # The "config" used by the fetchers
   mkConfig =
-    { sourcesFile ? ./sources.json
-    , sources ? builtins.fromJSON (builtins.readFile sourcesFile)
-    , pkgs ? mkPkgs sources
+    { sourcesFile ? if builtins.pathExists ./sources.json then ./sources.json else null
+    , sources ? if isNull sourcesFile then {} else builtins.fromJSON (builtins.readFile sourcesFile)
+    , system ? builtins.currentSystem
+    , pkgs ? mkPkgs sources system
     }: rec {
       # The sources, i.e. the attribute set of spec name to spec
       inherit sources;
@@ -145,5 +169,6 @@ let
       # The "pkgs" (evaluated nixpkgs) to use for e.g. non-builtin fetchers
       inherit pkgs;
     };
+
 in
 mkSources (mkConfig {}) // { __functor = _: settings: mkSources (mkConfig settings); }

--- a/nix/util.nix
+++ b/nix/util.nix
@@ -5,10 +5,10 @@ with haskell-nix.haskellLib;
 
   inherit
     selectProjectPackages
-    collectComponents';
+    collectComponents'
+    collectChecks';
 
   inherit (extra)
-    recRecurseIntoAttrs
-    collectChecks;
+    recRecurseIntoAttrs;
 
 }


### PR DESCRIPTION
This should not be merged until https://github.com/well-typed/canonical-json/pull/8 is merged and a new version of `canonical-json` is released. When that is done the commit "Temporarily use a patched version of canonical-json" can be dropped.