### PR TITLE
Move constraints to cabal files

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -3,7 +3,3 @@ index-state: 2022-09-21T00:00:00Z
 packages:
   cardano-prelude
   cardano-prelude-test
-
-constraints:
-  -- Only this supports ghc-9.2
-  canonical-json >= 0.6.0.1

--- a/cardano-prelude-test/cardano-prelude-test.cabal
+++ b/cardano-prelude-test/cardano-prelude-test.cabal
@@ -31,11 +31,11 @@ library
 
   build-depends:      base
                     , aeson
-                    , aeson-pretty >= 0.8.5
+                    , aeson-pretty            >= 0.8.5
                     , attoparsec
-                    , base16-bytestring >= 1
+                    , base16-bytestring       >= 1
                     , bytestring
-                    , canonical-json
+                    , canonical-json          >= 0.6.0.1
                     , cardano-prelude
                     , containers
                     , cryptonite

--- a/cardano-prelude/cardano-prelude.cabal
+++ b/cardano-prelude/cardano-prelude.cabal
@@ -12,6 +12,7 @@ copyright:            2018-2022 IOHK
 category:             Currency
 build-type:           Simple
 extra-source-files:   ChangeLog.md, README.md cbits/hashset.h cbits/worklist.h
+tested-with:          GHC == 9.2.4, GHC == 8.10.7
 
 flag development
   description: Disable `-Werror`
@@ -37,11 +38,11 @@ library
                       Cardano.Prelude.Orphans
                       Cardano.Prelude.Strict
 
-  build-depends:      base               >= 4.14       && < 4.18
+  build-depends:      base                    >= 4.14       && < 4.18
                     , aeson
-                    , base16-bytestring  >= 1
+                    , base16-bytestring       >= 1
                     , bytestring
-                    , canonical-json
+                    , canonical-json          >= 0.6.0.1
                     , cborg
                     , containers
                     , formatting


### PR DESCRIPTION
Only constraints in cabal files are propagated to downstream projects.